### PR TITLE
Fix the playground's mobile view not updating on component, variant, or theme switches

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,15 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "docs", "run", "dev"],
       "port": 4321
+    },
+    {
+      "name": "playground",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "cd playground && flutter run -d web-server --web-port=8123"
+      ],
+      "port": 8123
     }
   ]
 }

--- a/playground/lib/src/stage.dart
+++ b/playground/lib/src/stage.dart
@@ -55,6 +55,11 @@ class Stage extends StatelessWidget {
           child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(28, 56, 28, 52),
             child: _PhoneStage(
+              // Remount the phone when the component changes, so routes a
+              // demo pushed on the inner navigator (sheets, menus) don't
+              // linger over the next demo — a fresh stage per component,
+              // like the web canvas.
+              key: ObjectKey(item),
               // Keep the phone inside the pane on short windows.
               maxHeight: constraints.maxHeight - 108,
               // On the phone screen, object demos centre with room to
@@ -167,7 +172,7 @@ class _VariantPills extends StatelessWidget {
 /// status bar, "AI Chat" nav, dynamic island, side buttons and home
 /// indicator — the phone is chrome; the demo goes on the screen.
 class _PhoneStage extends StatelessWidget {
-  const _PhoneStage({required this.child, required this.maxHeight});
+  const _PhoneStage({super.key, required this.child, required this.maxHeight});
 
   final Widget child;
   final double maxHeight;
@@ -259,19 +264,33 @@ class _PhoneStage extends StatelessWidget {
                       data: Theme.of(
                         context,
                       ).copyWith(platform: TargetPlatform.iOS),
-                      child: Navigator(
-                        onGenerateRoute: (settings) => MaterialPageRoute<void>(
-                          settings: settings,
-                          builder: (_) => Material(
-                            color: shell.stageBg,
-                            child: Column(
-                              children: [
-                                const _StatusBar(),
-                                const _MobileNav(),
-                                Expanded(child: child),
-                              ],
-                            ),
-                          ),
+                      child: _PhoneScreenScope(
+                        demo: child,
+                        child: Navigator(
+                          onGenerateRoute: (settings) =>
+                              MaterialPageRoute<void>(
+                                settings: settings,
+                                // The navigator generates this route once and
+                                // keeps its builder for the route's lifetime,
+                                // so nothing per-build may be captured here:
+                                // the demo and palette are read through
+                                // `context` so component, variant, and theme
+                                // changes reach the screen.
+                                builder: (context) => Material(
+                                  color: ShellPalette.of(context).stageBg,
+                                  child: Column(
+                                    children: [
+                                      const _StatusBar(),
+                                      const _MobileNav(),
+                                      Expanded(
+                                        child: _PhoneScreenScope.demoOf(
+                                          context,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
                         ),
                       ),
                     ),
@@ -318,6 +337,26 @@ class _PhoneStage extends StatelessWidget {
       ],
     );
   }
+}
+
+/// Hands the stage's current demo through to the phone screen's route.
+///
+/// Rebuilding the [Navigator] widget never regenerates a live route, so the
+/// route content can't receive the demo as a closure capture — it would stay
+/// frozen at whatever was staged first. Instead the scope above the navigator
+/// carries the latest demo, and the route content depends on it, rebuilding
+/// whenever the stage stages something new.
+class _PhoneScreenScope extends InheritedWidget {
+  const _PhoneScreenScope({required this.demo, required super.child});
+
+  final Widget demo;
+
+  static Widget demoOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<_PhoneScreenScope>()!.demo;
+
+  @override
+  bool updateShouldNotify(_PhoneScreenScope oldWidget) =>
+      demo != oldWidget.demo;
 }
 
 class _StatusBar extends StatelessWidget {


### PR DESCRIPTION
## What

In mobile view, the phone screen stayed frozen on whatever demo was first staged — switching components, variants, or the light/dark theme changed nothing inside the frame. Web view was unaffected.

## Why

The mobile stage hosts the demo inside a nested `Navigator` (so adaptive menus present as bottom sheets *inside* the phone frame). A navigator calls `onGenerateRoute` only once, when first mounted, and the generated `MaterialPageRoute` keeps that builder closure for its whole lifetime — and the closure had captured the first build's demo widget and shell palette. Later rebuilds handed the navigator new closures, but the live route never re-ran them.

## How

- Added `_PhoneScreenScope`, an `InheritedWidget` above the nested navigator carrying the stage's current demo. The route content now reads the demo and palette through `context` at build time instead of via closure captures, so every stage rebuild notifies it and it re-renders with fresh values.
- Keyed `_PhoneStage` by the selected item, so switching components remounts the phone — sheets or menus the previous demo pushed on the inner navigator are dismissed instead of lingering over the next demo, matching the web canvas.
- Also adds a `playground` dev-server entry to `.claude/launch.json` alongside the existing `docs` one.

## Verification

Exercised live in Chrome (`flutter run -d web-server`): component switches (Full Chat → Add to Chat → Composer → Model Selector → Message), the Composer's Default → Streaming variant flip, and Dark ↔ Light theme all update inside the phone; the model-selector sheet still opens inside the frame with its scrim confined to the screen; switching components while a sheet is open lands on a clean stage; web mode unaffected. `flutter analyze` is clean.

## Reviewer notes

While testing, a pre-existing issue surfaced that this PR deliberately does not touch: at very narrow canvas widths the mock status bar can overflow (debug-only `RenderFlex` errors) and the phone frame clips rather than adapting. Tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground-only UI staging logic and a local dev launch config; no production auth, data, or API paths.
> 
> **Overview**
> Fixes the playground **mobile** phone frame staying stuck on the first staged demo when switching components, variants, or light/dark theme (web canvas was already fine).
> 
> The nested in-frame `Navigator` only builds its route once, so the route had **frozen** closure captures of the demo and shell colors. A new **`_PhoneScreenScope`** `InheritedWidget` above the navigator supplies the current demo; the route reads **`ShellPalette`** and the demo via **`context`** so rebuilds propagate. **`_PhoneStage`** is keyed with **`ObjectKey(item)`** so changing the selected component remounts the phone and clears inner routes (sheets/menus) from the previous demo.
> 
> Also adds a **`playground`** dev-server entry in **`.claude/launch.json`** (Flutter web on port 8123).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442c045b667b3666835df779a8c4447e4e5f0815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->