### PR TITLE
feat: migrate to material_ui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 Two hard constraints shape everything here:
 
-- **No third-party dependencies.** `dependencies:` in `pubspec.yaml` contains only the Flutter SDK. Dev dependencies (`flutter_test`, `flutter_lints`) are fine.
+- **No third-party dependencies.** `dependencies:` in `pubspec.yaml` contains only the Flutter SDK and Flutter's own first-party packages — `material_ui` (Material's home since Flutter 3.47) and its transitive set, all published by flutter.dev. Nothing outside that. Dev dependencies (`flutter_test`, `flutter_lints`) are fine.
 - **Nothing model-facing.** Components render state passed in and report intent out through callbacks. No prompts, schemas, provider/network calls, or any LLM awareness — that belongs to the layers built on top.
 
 The theme, the conversation components (message, thread, streaming text, actions, loading), the composer and its menus, attachments with their preview, suggestions, and the chat surface are implemented; the roadmap below tracks the rest. Message content is modeled as typed parts (`lib/src/models/`) — sealed `FlowMessagePart` subtypes rendered by `FlowMessage`, with `FlowCustomPart` + `FlowCustomPartBuilder` as the extension seam for host-injected content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,11 @@
 
 ## 0.2.0 (unreleased)
 
-- Migrated from `package:flutter/material.dart` to `package:material_ui` —
-  Material's home since Flutter 3.47. No API changes: every widget keeps
-  its name and shape.
-- **Breaking**: the host app must be on material_ui too. The legacy and
-  packaged Material are distinct types, so a legacy `ThemeData(extensions:)`
-  no longer accepts `FlowTheme`. Migrate the app with
-  `dart fix --apply --code=migrate_design_widgets`, or pin flow_ui 0.1.x.
-- Requires Flutter 3.44 or newer, with `material_ui: ^1.0.0` alongside
-  flow_ui in the app's pubspec.
+- **Breaking**: migrated from `package:flutter/material.dart` to
+  `package:material_ui` (Material's home since Flutter 3.47) — no API
+  changes, but the two Materials are distinct types, so the host app must
+  migrate too: `dart fix --apply --code=migrate_design_widgets` on
+  Flutter 3.44+, or pin flow_ui 0.1.x.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,15 @@
 
 ## 0.2.0 (unreleased)
 
-flow_ui now builds on `package:material_ui` — Material's home since
-Flutter 3.47 moved the design libraries out of the SDK. Every widget keeps
-its name and shape: the change is the foundation, not the API.
-
-It does mean the app must be on material_ui too. The legacy
-`package:flutter/material.dart` and material_ui are distinct types — a
-legacy `ThemeData(extensions:)` won't accept `FlowTheme`, and the compiler
-says so out loud. Migrate the app with
-`dart fix --apply --code=migrate_design_widgets` (Flutter 3.44 or newer);
-apps staying on the legacy import should pin flow_ui 0.1.x.
+- Migrated from `package:flutter/material.dart` to `package:material_ui` —
+  Material's home since Flutter 3.47. No API changes: every widget keeps
+  its name and shape.
+- **Breaking**: the host app must be on material_ui too. The legacy and
+  packaged Material are distinct types, so a legacy `ThemeData(extensions:)`
+  no longer accepts `FlowTheme`. Migrate the app with
+  `dart fix --apply --code=migrate_design_widgets`, or pin flow_ui 0.1.x.
+- Requires Flutter 3.44 or newer, with `material_ui: ^1.0.0` alongside
+  flow_ui in the app's pubspec.
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 (unreleased)
+
+flow_ui now builds on `package:material_ui` — Material's home since
+Flutter 3.47 moved the design libraries out of the SDK. Every widget keeps
+its name and shape: the change is the foundation, not the API.
+
+It does mean the app must be on material_ui too. The legacy
+`package:flutter/material.dart` and material_ui are distinct types — a
+legacy `ThemeData(extensions:)` won't accept `FlowTheme`, and the compiler
+says so out loud. Migrate the app with
+`dart fix --apply --code=migrate_design_widgets` (Flutter 3.44 or newer);
+apps staying on the legacy import should pin flow_ui 0.1.x.
+
 ## 0.1.0
 
 First public release — the assistant UI component library for Flutter, with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Two hard constraints shape everything here:
 
-- **No third-party dependencies.** `dependencies:` in `pubspec.yaml` contains only the Flutter SDK. Dev dependencies (`flutter_test`, `flutter_lints`) are fine. Bundled *assets* are not dependencies: the package ships Figtree (`fonts/`, SIL OFL) because the design system is set in it, declared under `flutter: fonts:` and referenced as `package: 'flow_ui'`.
+- **No third-party dependencies.** `dependencies:` in `pubspec.yaml` contains only the Flutter SDK and Flutter's own first-party packages — `material_ui` (Material's home since Flutter 3.47) and its transitive set, all published by flutter.dev. Nothing outside that. Dev dependencies (`flutter_test`, `flutter_lints`) are fine. Bundled *assets* are not dependencies: the package ships Figtree (`fonts/`, SIL OFL) because the design system is set in it, declared under `flutter: fonts:` and referenced as `package: 'flow_ui'`.
 - **Nothing model-facing.** Components render state passed in and report intent out through callbacks. No prompts, schemas, provider/network calls, or any LLM awareness — that belongs to the layers built on top.
 
 The theme, the conversation components (message, thread, streaming text, actions, loading), the composer and its menus, attachments with their preview, suggestions, and the chat surface are implemented; the roadmap below tracks the rest. Message content is modeled as typed parts (`lib/src/models/`) — sealed `FlowMessagePart` subtypes rendered by `FlowMessage`, with `FlowCustomPart` + `FlowCustomPartBuilder` as the extension seam for host-injected content.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 void main() => runApp(const ExampleApp());
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,10 +5,12 @@ version: 0.1.0
 
 environment:
   sdk: ^3.12.2
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
   flow_ui:
     path: ../
 

--- a/lib/flow_ui.dart
+++ b/lib/flow_ui.dart
@@ -2,7 +2,8 @@
 /// to build production-grade Chat & AI assistant interfaces.
 ///
 /// flow_ui renders state and reports intent through callbacks — it contains
-/// nothing model-facing and depends only on the Flutter SDK.
+/// nothing model-facing and builds only on Flutter's own first-party
+/// packages.
 library;
 
 export 'src/models/flow_attachment.dart';

--- a/lib/src/theme/flow_colors.dart
+++ b/lib/src/theme/flow_colors.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Semantic color tokens for flow_ui components.
 ///

--- a/lib/src/theme/flow_theme.dart
+++ b/lib/src/theme/flow_theme.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'flow_colors.dart';
 import 'flow_typography.dart';

--- a/lib/src/theme/flow_typography.dart
+++ b/lib/src/theme/flow_typography.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// The typeface the presets are drawn in, bundled with this package under
 /// `fonts/` (SIL Open Font License — see `fonts/OFL.txt`).

--- a/lib/src/utils/flow_attachment_error.dart
+++ b/lib/src/utils/flow_attachment_error.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 

--- a/lib/src/utils/flow_circle_button.dart
+++ b/lib/src/utils/flow_circle_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 // Internal chrome shared by the composer, the attachment tiles and the
 // attachment preview. Not exported from the package barrel.

--- a/lib/src/utils/flow_menu_core.dart
+++ b/lib/src/utils/flow_menu_core.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../widgets/flow_menu_style.dart';

--- a/lib/src/utils/flow_menu_sheet.dart
+++ b/lib/src/utils/flow_menu_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../widgets/flow_menu_style.dart';
@@ -42,10 +42,13 @@ class FlowMenuSheetPage {
 
 /// Opens [root] as a modal bottom sheet styled like the anchored menus.
 ///
-/// Rides the Material modal-sheet route, which itself requires
+/// Rides material_ui's modal-sheet route, which itself requires its
 /// [MaterialLocalizations]: a host not built on [MaterialApp] must list
 /// `DefaultMaterialLocalizations.delegate` in its `localizationsDelegates`
-/// for the phone presentation. Nothing else in the package needs it.
+/// for the phone presentation — localized apps get it through
+/// `GlobalMaterialLocalizations.delegates`, which since the material_ui
+/// move also bundles the widgets and Cupertino delegates. Nothing else in
+/// the package needs it.
 Future<void> showFlowMenuSheet({
   required BuildContext context,
   required FlowMenuSheetPage root,

--- a/lib/src/widgets/flow_attachment_group.dart
+++ b/lib/src/widgets/flow_attachment_group.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
 import '../theme/flow_theme.dart';

--- a/lib/src/widgets/flow_attachment_preview.dart
+++ b/lib/src/widgets/flow_attachment_preview.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
 import '../theme/flow_theme.dart';
@@ -116,7 +116,7 @@ class FlowAttachmentPreview extends StatefulWidget {
   /// Which one opens first.
   final int initialIndex;
 
-  /// Host-localized; defaults to the framework's own close-button label when
+  /// Host-localized; defaults to material_ui's own close-button label when
   /// [MaterialLocalizations] is available, so the package still ships no
   /// strings of its own.
   final String? closeTooltip;

--- a/lib/src/widgets/flow_chat_screen.dart
+++ b/lib/src/widgets/flow_chat_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
 import '../theme/flow_theme.dart';

--- a/lib/src/widgets/flow_greeting.dart
+++ b/lib/src/widgets/flow_greeting.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../utils/flow_menu_core.dart';
@@ -74,7 +74,7 @@ class FlowMenuOption extends FlowMenuEntry {
 /// with children becomes a submenu. [presentation] forces the anchored menu
 /// or the sheet, and [menuStyle] overrides the token-derived look.
 ///
-/// The sheet rides the Material modal route, so a host not built on
+/// The sheet rides material_ui's modal route, so a host not built on
 /// [MaterialApp] needs `DefaultMaterialLocalizations.delegate` among its
 /// `localizationsDelegates` for the phone presentation.
 class FlowMenu extends StatefulWidget {

--- a/lib/src/widgets/flow_menu_style.dart
+++ b/lib/src/widgets/flow_menu_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// How a flow_ui menu presents when its trigger is tapped.
 enum FlowMenuPresentation {

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../utils/flow_state_colors.dart';

--- a/lib/src/widgets/flow_model_selector.dart
+++ b/lib/src/widgets/flow_model_selector.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../utils/flow_menu_core.dart';
@@ -64,7 +64,7 @@ class FlowEffortOption {
 /// automatic by platform unless forced — and [menuStyle] overrides the
 /// token-derived look.
 ///
-/// The sheet rides the Material modal route, so a host not built on
+/// The sheet rides material_ui's modal route, so a host not built on
 /// [MaterialApp] needs `DefaultMaterialLocalizations.delegate` among its
 /// `localizationsDelegates` for the phone presentation.
 class FlowModelSelector extends StatefulWidget {

--- a/lib/src/widgets/flow_shimmer_text.dart
+++ b/lib/src/widgets/flow_shimmer_text.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 

--- a/lib/src/widgets/flow_streaming_text.dart
+++ b/lib/src/widgets/flow_streaming_text.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 

--- a/lib/src/widgets/flow_suggestion.dart
+++ b/lib/src/widgets/flow_suggestion.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import '../utils/flow_state_colors.dart';

--- a/lib/src/widgets/flow_thinking_indicator.dart
+++ b/lib/src/widgets/flow_thinking_indicator.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../theme/flow_theme.dart';
 import 'flow_shimmer_text.dart';

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_message_data.dart';
 import 'flow_message.dart';

--- a/playground/analysis_options.yaml
+++ b/playground/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'src/code_panel.dart';
 import 'src/embed.dart';

--- a/playground/lib/src/code_panel.dart
+++ b/playground/lib/src/code_panel.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 import 'package:syntax_highlight/syntax_highlight.dart';

--- a/playground/lib/src/demo_registry.dart
+++ b/playground/lib/src/demo_registry.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'demos/add_to_chat_demo.dart';
 import 'demos/attachments_demo.dart';

--- a/playground/lib/src/demos/add_to_chat_demo.dart
+++ b/playground/lib/src/demos/add_to_chat_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 const String addToChatSnippet = '''

--- a/playground/lib/src/demos/attachments_demo.dart
+++ b/playground/lib/src/demos/attachments_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 import 'demo_content.dart';

--- a/playground/lib/src/demos/composer_demo.dart
+++ b/playground/lib/src/demos/composer_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 import 'demo_content.dart';

--- a/playground/lib/src/demos/full_chat_demo.dart
+++ b/playground/lib/src/demos/full_chat_demo.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 /// The canned reply, per the design prototype.

--- a/playground/lib/src/demos/greeting_demo.dart
+++ b/playground/lib/src/demos/greeting_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 const String greetingSnippet = '''

--- a/playground/lib/src/demos/message_actions_demo.dart
+++ b/playground/lib/src/demos/message_actions_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String messageActionsSnippet = '''
 FlowMessageActions(

--- a/playground/lib/src/demos/message_demo.dart
+++ b/playground/lib/src/demos/message_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String messageSnippet = '''
 Column(

--- a/playground/lib/src/demos/model_selector_demo.dart
+++ b/playground/lib/src/demos/model_selector_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'demo_content.dart';
 

--- a/playground/lib/src/demos/shimmer_text_demo.dart
+++ b/playground/lib/src/demos/shimmer_text_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String shimmerTextSnippet = '''
 FlowShimmerText(

--- a/playground/lib/src/demos/streaming_message_demo.dart
+++ b/playground/lib/src/demos/streaming_message_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String streamingMessageSnippet = '''
 Column(

--- a/playground/lib/src/demos/streaming_text_demo.dart
+++ b/playground/lib/src/demos/streaming_text_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String streamingTextSnippet = '''
 FlowStreamingText(

--- a/playground/lib/src/demos/suggestions_demo.dart
+++ b/playground/lib/src/demos/suggestions_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 const String suggestionsSnippet = '''

--- a/playground/lib/src/demos/thinking_indicator_demo.dart
+++ b/playground/lib/src/demos/thinking_indicator_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String thinkingIndicatorSnippet = '''
 FlowThinkingIndicator(

--- a/playground/lib/src/demos/thread_demo.dart
+++ b/playground/lib/src/demos/thread_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const String threadSnippet = '''
 // A reversed, scrollable conversation — newest at the bottom. Give it

--- a/playground/lib/src/embed.dart
+++ b/playground/lib/src/embed.dart
@@ -1,5 +1,5 @@
 import 'package:flow_ui/flow_ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'demo_registry.dart';
 import 'playground_item.dart';

--- a/playground/lib/src/flow_logo.dart
+++ b/playground/lib/src/flow_logo.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 /// The Flow UI mark (Figma node 308:94), rendered from the SVG asset: the

--- a/playground/lib/src/playground_item.dart
+++ b/playground/lib/src/playground_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 /// The sidebar's destinations — one example plus the component demos to

--- a/playground/lib/src/playground_shell.dart
+++ b/playground/lib/src/playground_shell.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'code_panel.dart';
 import 'demo_registry.dart';

--- a/playground/lib/src/shell_palette.dart
+++ b/playground/lib/src/shell_palette.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// The playground's accent — the design's pink, drawn on the logo tile and
 /// the active sidebar icon.

--- a/playground/lib/src/sidebar.dart
+++ b/playground/lib/src/sidebar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 
 import 'open_docs.dart';

--- a/playground/lib/src/stage.dart
+++ b/playground/lib/src/stage.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 

--- a/playground/lib/src/top_bar.dart
+++ b/playground/lib/src/top_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 

--- a/playground/pubspec.lock
+++ b/playground/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   device_info_plus:
     dependency: transitive
     description:
@@ -119,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -133,6 +141,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -167,6 +180,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   irondash_engine_context:
     dependency: transitive
     description:
@@ -219,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -231,14 +252,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: "direct main"
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   path:
     dependency: transitive
     description:
@@ -360,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -408,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/playground/pubspec.yaml
+++ b/playground/pubspec.yaml
@@ -20,6 +20,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.12.2
+  flutter: ">=3.44.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -30,12 +31,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
   # The component library under demo — also supplies Figtree, the face the
   # playground chrome is set in.
   flow_ui:
     path: ../
-  # Renders the logo's SVG asset. App-only: flow_ui itself stays
-  # dependency-free.
+  # Renders the logo's SVG asset — app-only.
   flutter_svg: ^2.0.10
   # The icon set the design is drawn in.
   phosphoricons_flutter: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flow_ui
 description: Flow UI is an open-source Flutter UI library to build production-grade Chat & AI assistant interfaces.
-version: 0.1.0
+version: 0.2.0
 homepage: https://flowui.stac.dev/
 repository: https://github.com/StacDev/flow_ui
 issue_tracker: https://github.com/StacDev/flow_ui/issues
@@ -19,6 +19,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:
@@ -29,7 +30,7 @@ flutter:
   # Figtree is the typeface of the Flow UI design file. It ships with the
   # package (SIL Open Font License, see fonts/OFL.txt) so the default theme
   # renders as designed without the host bundling a font — and without a
-  # dependency, which this package does not take.
+  # font dependency.
   #
   # Static instances rather than the variable TTF: Flutter maps FontWeight to
   # the nearest declared weight, so a weight axis would not be interpolated.


### PR DESCRIPTION
## Description

Flutter 3.47 moved Material out of the SDK into `package:material_ui`, and the legacy `flutter/material.dart` gets formally deprecated in November. This migrates flow_ui over now, so apps that have migrated don't need `MaterialUiCompatibilityBridge` around us.

It's a clean import swap — all 48 imports, zero API changes needed. Pubspec goes to 0.2.0 with `material_ui: ^1.0.0`; the Flutter floor stays at 3.44 (verified material_ui runs fine there).

Heads up, this is breaking: the legacy and new Material are different types, so host apps must migrate too — a legacy `ThemeData(extensions:)` won't compile with `FlowTheme` anymore, and apps staying on the old import should pin 0.1.x.

We're landing this now but holding the 0.2.0 publish (and the README/docs install copy) until Sept–Oct, once material_ui has a few patches behind it. The docs site stays on the current deploy till then.

Tested: analyze clean on 3.47, full playground run (composer, menus, sheet, both themes), example + wasm builds, publish dry-run.

One more thing — stac_ai's git dep on flow_ui is unpinned and still points at the old `flow_ui/` subdir, so it needs fixing on its side before it pulls this.

## Related Issues

None.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [x] Build configuration change
- [ ] Documentation
- [ ] Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking dependency and import migration affects every consumer’s compile-time Material types and theme integration; scope is wide but behavior is intended to be a straight swap.
> 
> **Overview**
> **Breaking release (0.2.0):** the library now depends on `material_ui: ^1.0.0` and imports `package:material_ui/material_ui.dart` instead of `package:flutter/material.dart` across `lib/`, the example app, and the playground. Public widget APIs are unchanged at the source level, but Material types from the legacy SDK import are not the same as `material_ui`, so consumers must migrate their apps (e.g. `dart fix --apply --code=migrate_design_widgets` on Flutter 3.44+) or stay on flow_ui 0.1.x.
> 
> `pubspec.yaml` bumps the package to **0.2.0** and sets **Flutter >=3.44.0**; the example and playground add a direct `material_ui` dependency and lockfile updates. **CHANGELOG** documents the breaking migration. Agent docs clarify that “no third-party deps” still allows Flutter first-party packages including `material_ui`. **Analyzer** configs exclude platform/build folders for root and playground. Menu/sheet doc comments note `material_ui` localization expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75af4957a1d7e4de944f8cb37ea3fdc5a0a9935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->