### PR TITLE
feat: pill, code block, and error card polish

### DIFF
--- a/lib/src/widgets/flow_code_block.dart
+++ b/lib/src/widgets/flow_code_block.dart
@@ -92,8 +92,8 @@ class FlowCodeBlock extends StatefulWidget {
 
 class _FlowCodeBlockState extends State<FlowCodeBlock> {
   /// The design's block: the message bubble's 12px corner, code inset
-  /// 16/12, and a 36 header — 6px around the copy affordance's 24 frame,
-  /// with the label a full 16 from the edge so it aligns with the code.
+  /// 16/12, and a ruleless header standing 10 off the top and 12 from the
+  /// end, its label a full 16 from the edge so it aligns with the code.
   static const BorderRadius _radius = BorderRadius.all(Radius.circular(12));
   static const EdgeInsetsGeometry _bodyPadding = EdgeInsets.symmetric(
     horizontal: 16,
@@ -102,12 +102,55 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
   static const double _headerHeight = 36;
   static const EdgeInsetsGeometry _headerPadding = EdgeInsets.only(
     left: 16,
-    right: 6,
+    right: 12,
+    top: 10,
   );
 
-  /// The block's ground: the same 4% ink wash as the user bubble and the
-  /// attachment tiles, edged with the tiles' outline hairline.
-  static const double _groundOpacity = 0.04;
+  /// The copy affordance reveals with the pointer — short enough to feel
+  /// like part of the hover itself, the attachment tiles' idiom.
+  static const Duration _revealDuration = Duration(milliseconds: 120);
+
+  bool _hovered = false;
+  bool _copyFocused = false;
+
+  /// Whether the user is currently driving the UI with a device that can
+  /// hover — the attachment group's idiom: the framework tracks and
+  /// *revises* this, where a platform check could strand the affordance
+  /// invisible on a hybrid device.
+  late bool _hoverCapable;
+
+  @override
+  void initState() {
+    super.initState();
+    _hoverCapable = _hoverCapableNow;
+    FocusManager.instance.addHighlightModeListener(_handleHighlightModeChange);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(
+      _handleHighlightModeChange,
+    );
+    super.dispose();
+  }
+
+  static bool get _hoverCapableNow =>
+      FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
+
+  void _handleHighlightModeChange(FocusHighlightMode mode) {
+    if (!mounted) return;
+    final value = mode == FocusHighlightMode.traditional;
+    if (_hoverCapable != value) setState(() => _hoverCapable = value);
+  }
+
+  /// Hover-revealing is a pointer affordance: it needs a hovering device
+  /// *and* a non-phone platform — the theme's platform rather than the
+  /// real one, like the menus' sheet resolution.
+  bool _revealsOnHover(BuildContext context) {
+    if (!_hoverCapable) return false;
+    final platform = Theme.of(context).platform;
+    return platform != TargetPlatform.iOS && platform != TargetPlatform.android;
+  }
 
   /// The last highlight and the inputs it was computed from. Tokenizing
   /// re-scans the whole source, so a rebuild that changes none of the
@@ -175,52 +218,84 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
             child: code,
           );
 
-    return Container(
-      width: double.infinity,
-      clipBehavior: Clip.antiAlias,
-      decoration: BoxDecoration(
-        color: colors.onSurface.withValues(alpha: _groundOpacity),
-        borderRadius: widget.borderRadius ?? _radius,
-        border: Border.all(color: colors.outline),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (hasHeader)
-            Container(
-              height: _headerHeight,
-              padding: _headerPadding,
-              decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(color: colors.outlineVariant),
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: Container(
+        width: double.infinity,
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: colors.surfaceContainerLowest,
+          borderRadius: widget.borderRadius ?? _radius,
+          // The hover state lives on the edge, not the ground: the
+          // hairline firms from the faint rung to the ladder's deepest.
+          border: Border.all(
+            color: _hovered
+                ? colors.surfaceContainerHighest
+                : colors.outlineVariant,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (hasHeader)
+              Container(
+                height: _headerHeight,
+                padding: _headerPadding,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: label == null
+                          ? const SizedBox.shrink()
+                          : Text(
+                              label,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: typography.bodySmall.copyWith(
+                                color: colors.onSurfaceMuted,
+                              ),
+                            ),
+                    ),
+                    if (showCopy)
+                      // Revealed by the pointer on hover-capable devices,
+                      // always present on phones (by the theme's platform,
+                      // so hosts and tests can steer it) or wherever
+                      // hovering isn't how the UI is being driven — and
+                      // kept while focused, so keyboard users aren't
+                      // copying blind. Opacity alone still hit-tests, so
+                      // the hidden affordance must also ignore the
+                      // pointer.
+                      IgnorePointer(
+                        ignoring:
+                            _revealsOnHover(context) &&
+                            !_hovered &&
+                            !_copyFocused,
+                        child: AnimatedOpacity(
+                          opacity:
+                              !_revealsOnHover(context) ||
+                                  _hovered ||
+                                  _copyFocused
+                              ? 1
+                              : 0,
+                          duration: MediaQuery.disableAnimationsOf(context)
+                              ? Duration.zero
+                              : _revealDuration,
+                          child: _CopyButton(
+                            copied: widget.copied,
+                            tooltip: widget.copyTooltip,
+                            onTap: widget.onCopy!,
+                            onFocusChange: (value) =>
+                                setState(() => _copyFocused = value),
+                          ),
+                        ),
+                      ),
+                  ],
                 ),
               ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: label == null
-                        ? const SizedBox.shrink()
-                        : Text(
-                            label,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: typography.labelMedium.copyWith(
-                              color: colors.onSurfaceVariant,
-                            ),
-                          ),
-                  ),
-                  if (showCopy)
-                    _CopyButton(
-                      copied: widget.copied,
-                      tooltip: widget.copyTooltip,
-                      onTap: widget.onCopy!,
-                    ),
-                ],
-              ),
-            ),
-          body,
-        ],
+            body,
+          ],
+        ),
       ),
     );
   }
@@ -234,20 +309,22 @@ class _CopyButton extends StatefulWidget {
     required this.copied,
     required this.tooltip,
     required this.onTap,
+    required this.onFocusChange,
   });
 
   final bool copied;
   final String? tooltip;
   final VoidCallback onTap;
+  final ValueChanged<bool> onFocusChange;
 
   @override
   State<_CopyButton> createState() => _CopyButtonState();
 }
 
 class _CopyButtonState extends State<_CopyButton> {
-  /// Breathing room around the 16 glyph inside its 24 frame.
-  static const double _framePadding = 4;
-  static const double _iconSize = 16;
+  /// Breathing room around the 14 glyph inside its 24 frame.
+  static const double _framePadding = 5;
+  static const double _iconSize = 14;
 
   /// The frame's corner — a step under the block's 12, per the ratio the
   /// menu rows keep to their card.
@@ -275,6 +352,7 @@ class _CopyButtonState extends State<_CopyButton> {
       child: InkWell(
         onTap: widget.onTap,
         onHover: (value) => setState(() => _hovered = value),
+        onFocusChange: widget.onFocusChange,
         borderRadius: _frameRadius,
         hoverColor: colors.surfaceContainerHigh,
         child: Padding(

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -6,6 +6,7 @@ import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';
 import '../utils/flow_gradient_outline.dart';
 import 'flow_attachment_group.dart';
+import 'flow_pill.dart';
 
 /// The message input area: an auto-growing text field with an action bar
 /// and a send button that morphs into stop while [isStreaming].
@@ -130,6 +131,11 @@ class _FlowComposerState extends State<FlowComposer> {
   static const double _leadingGap = 4;
   static const double _trailingGap = 8;
 
+  /// Between two neighbouring pills in the action row — the design's 8,
+  /// closing to 6 on phones.
+  static const double _pillGap = 8;
+  static const double _mobilePillGap = 6;
+
   /// The field's floor, sized so an empty composer stands at the design's
   /// 116px: 19 + 38 + 16 (gap) + 32 (action row) + 11.
   static const double _fieldMinHeight = 38;
@@ -195,6 +201,13 @@ class _FlowComposerState extends State<FlowComposer> {
     if (_focused != _attachedFocusNode.hasFocus) {
       setState(() => _focused = _attachedFocusNode.hasFocus);
     }
+  }
+
+  /// The theme's platform rather than the real one, like the menus' sheet
+  /// resolution, so hosts and tests can steer it without a device.
+  static bool _isMobile(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
   }
 
   void _send() {
@@ -382,9 +395,19 @@ class _FlowComposerState extends State<FlowComposer> {
                 padding: const EdgeInsets.symmetric(horizontal: _actionInset),
                 child: Row(
                   children: [
-                    for (final action in widget.leadingActions) ...[
-                      action,
-                      const SizedBox(width: _leadingGap),
+                    for (var i = 0; i < widget.leadingActions.length; i++) ...[
+                      widget.leadingActions[i],
+                      // Two neighbouring pills read as a set and take the
+                      // design's wider step — 8, closing to 6 on phones —
+                      // while everything else keeps the action row's 4.
+                      SizedBox(
+                        width:
+                            i + 1 < widget.leadingActions.length &&
+                                widget.leadingActions[i] is FlowPill &&
+                                widget.leadingActions[i + 1] is FlowPill
+                            ? (_isMobile(context) ? _mobilePillGap : _pillGap)
+                            : _leadingGap,
+                      ),
                     ],
                     const Spacer(),
                     for (final action in widget.trailingActions) ...[

--- a/lib/src/widgets/flow_error_state.dart
+++ b/lib/src/widgets/flow_error_state.dart
@@ -74,13 +74,14 @@ class FlowErrorState extends StatelessWidget {
   static const double _groundOpacity = 0.02;
   static const double _borderOpacity = 0.4;
 
-  /// The glyph, and the indent that hangs the message and the pill under
-  /// the text rather than under the glyph.
-  static const double _iconSize = 20;
-  static const double _iconGap = 10;
+  /// The glyph, sized to the title's line so the pair reads as one row;
+  /// the message and the pill align to the card's edge below, not to the
+  /// text's indent.
+  static const double _iconSize = 16;
+  static const double _iconGap = 6;
 
   /// Gaps: glyph row to message, content to the retry pill.
-  static const double _messageGap = 4;
+  static const double _messageGap = 8;
   static const double _retryGap = 12;
 
   @override
@@ -97,23 +98,28 @@ class FlowErrorState extends StatelessWidget {
     final rowText = title ?? message;
     final below = title == null ? null : message;
 
+    final rowStyle = title != null
+        ? typography.labelLarge.copyWith(
+            fontWeight: FontWeight.w600,
+            color: colors.onSurface,
+          )
+        : typography.bodyMedium.copyWith(color: colors.onSurfaceVariant);
+
     Widget? rowLabel;
     if (rowText != null) {
-      rowLabel = Text(
-        rowText,
-        style: title != null
-            ? typography.labelLarge.copyWith(
-                fontWeight: FontWeight.w600,
-                color: colors.onSurface,
-              )
-            : typography.bodyMedium.copyWith(color: colors.onSurfaceVariant),
-      );
+      rowLabel = Text(rowText, style: rowStyle);
       if (below == null) {
         // The row text is all the card says — a lone title as much as a
         // lone message — and failures arrive unprompted: announce it.
         rowLabel = Semantics(liveRegion: true, child: rowLabel);
       }
     }
+
+    // The glyph centres on the text's *first line* — a box the line's own
+    // height keeps it optically centred beside a one-line title and on
+    // the opening line of a wrapping message alike.
+    final firstLineHeight =
+        (rowStyle.fontSize ?? _iconSize) * (rowStyle.height ?? 1);
 
     return Container(
       padding: padding ?? _cardPadding,
@@ -132,7 +138,16 @@ class FlowErrorState extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Icon(Icons.error_outline, size: _iconSize, color: colors.error),
+              SizedBox(
+                height: firstLineHeight,
+                child: Center(
+                  child: Icon(
+                    Icons.error_outline,
+                    size: _iconSize,
+                    color: colors.error,
+                  ),
+                ),
+              ),
               if (rowLabel != null) ...[
                 const SizedBox(width: _iconGap),
                 Flexible(child: rowLabel),
@@ -141,10 +156,7 @@ class FlowErrorState extends StatelessWidget {
           ),
           if (below != null)
             Padding(
-              padding: const EdgeInsets.only(
-                left: _iconSize + _iconGap,
-                top: _messageGap,
-              ),
+              padding: const EdgeInsets.only(top: _messageGap),
               child: Semantics(
                 liveRegion: true,
                 child: Text(
@@ -157,10 +169,7 @@ class FlowErrorState extends StatelessWidget {
             ),
           if (onRetry != null)
             Padding(
-              padding: const EdgeInsets.only(
-                left: _iconSize + _iconGap,
-                top: _retryGap,
-              ),
+              padding: const EdgeInsets.only(top: _retryGap),
               child: _RetryButton(onTap: onRetry, label: retryLabel),
             ),
         ],

--- a/lib/src/widgets/flow_pill.dart
+++ b/lib/src/widgets/flow_pill.dart
@@ -17,9 +17,11 @@ import '../utils/flow_state_colors.dart';
 ///   )
 /// ```
 ///
-/// The X reports removal through [onRemove]; actually turning the tool off
-/// is the host's move. On phones the label drops away to the design's
-/// icon-only form (see [showLabel]).
+/// The whole pill is one control: hovering highlights it edge to edge and
+/// tapping anywhere on it reports through [onRemove] — the X is the visual
+/// affordance, not a separate target. Actually turning the tool off is the
+/// host's move. On phones the label drops away to the design's icon-only
+/// form (see [showLabel]).
 ///
 /// A pill without [onRemove] is a static status token in full ink, not a
 /// disabled control — unlike `FlowSuggestion`, where a null tap renders
@@ -47,21 +49,22 @@ class FlowPill extends StatefulWidget {
   /// the labeled form is in effect (see [showLabel]).
   final String label;
 
-  /// Remove intent from the trailing X; null leaves the X off entirely —
-  /// a static status pill.
+  /// Remove intent — the whole pill's tap, with the trailing X as its
+  /// affordance. Null leaves the X off entirely: a static status pill.
   final VoidCallback? onRemove;
 
-  /// Optional tap on the pill's body, e.g. reopening the tool's options.
-  /// Null leaves the body inert without reading disabled.
+  /// Tap on the pill when it is *not* removable, e.g. reopening the
+  /// tool's options. With [onRemove] set the pill's tap is removal and
+  /// this is ignored.
   final VoidCallback? onTap;
 
-  /// Host-localized label for the X, e.g. 'Turn off Research' — its
-  /// tooltip and accessible name. Pass one whenever [onRemove] is set, or
-  /// assistive tech announces an unnamed button.
+  /// Host-localized name for the removal tap, e.g. 'Turn off Research' —
+  /// the pill's tooltip while removable. Pass one whenever [onRemove] is
+  /// set, or the affordance goes unexplained.
   final String? removeTooltip;
 
-  /// Host-localized tooltip over the pill's body — the tool's name when a
-  /// host forces the icon-only form on a hovering device.
+  /// Host-localized tooltip while the pill is not removable — the tool's
+  /// name when a host forces the icon-only form on a hovering device.
   final String? tooltip;
 
   /// Whether the label is drawn. Null resolves by platform — hidden on
@@ -97,7 +100,7 @@ class _FlowPillState extends State<FlowPill> {
   static const double _gap = 6;
   static const double _compactGap = 4;
 
-  bool _removeHovered = false;
+  bool _hovered = false;
 
   bool _labelVisible(BuildContext context) {
     final show = widget.showLabel;
@@ -115,16 +118,23 @@ class _FlowPillState extends State<FlowPill> {
     final gap = showLabel ? _gap : _compactGap;
     final hasRemove = widget.onRemove != null;
 
-    // Content rests in full ink; the X a step down at the muted chrome
-    // level, lifting to full on hover. Disabling fades each from its own
-    // rest, so the X stays proportionally fainter.
-    final foreground = enabled
+    // Removal is the pill's tap when it has one; a status pill may still
+    // carry a body tap of its own.
+    final VoidCallback? tapAction = hasRemove ? widget.onRemove : widget.onTap;
+
+    // The glyph rests a step down in the secondary ink, the label in full
+    // ink, and the X at the muted chrome level — lifting to full ink as
+    // the pill is hovered. Disabling fades each from its own rest.
+    final iconForeground = enabled
+        ? colors.onSurfaceVariant
+        : flowDisabledColor(colors.onSurfaceVariant);
+    final labelForeground = enabled
         ? colors.onSurface
         : flowDisabledColor(colors.onSurface);
     final removeRest = enabled
         ? colors.onSurfaceMuted
         : flowDisabledColor(colors.onSurfaceMuted);
-    final removeForeground = _removeHovered && enabled
+    final removeForeground = _hovered && enabled
         ? colors.onSurface
         : removeRest;
 
@@ -133,9 +143,9 @@ class _FlowPillState extends State<FlowPill> {
       side: BorderSide(color: colors.outlineVariant),
     );
 
-    // The X's target spans the pill's full height and absorbs the end
-    // inset, so splitting the padding needs the resolved sides — start on
-    // the body, end inside the X — kept directional so RTL swaps them.
+    // The X absorbs the end inset so the affordance reaches the pill's
+    // edge; splitting the padding needs the resolved sides — start on the
+    // body, end after the X — kept directional so RTL swaps them.
     final direction = Directionality.of(context);
     final resolved = (widget.padding ?? _padding).resolve(direction);
     final startInset = direction == TextDirection.ltr
@@ -145,108 +155,84 @@ class _FlowPillState extends State<FlowPill> {
         ? resolved.right
         : resolved.left;
 
-    Widget body = Padding(
+    final content = Padding(
       padding: EdgeInsetsDirectional.only(
         start: startInset,
-        end: hasRemove ? 0 : endInset,
+        end: endInset,
         top: resolved.top,
         bottom: resolved.bottom,
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(widget.icon, size: _iconSize, color: foreground),
+          Icon(widget.icon, size: _iconSize, color: iconForeground),
           if (showLabel) ...[
             const SizedBox(width: _gap),
             Text(
               widget.label,
               style: typography.labelLarge.copyWith(
                 fontWeight: FontWeight.w500,
-                color: foreground,
+                color: labelForeground,
               ),
             ),
+          ],
+          if (hasRemove) ...[
+            SizedBox(width: gap),
+            Icon(Icons.close, size: _removeSize, color: removeForeground),
           ],
         ],
       ),
     );
 
-    if (widget.onTap != null) {
-      body = InkWell(
-        onTap: enabled ? widget.onTap : null,
-        hoverColor: colors.surfaceContainerLow,
-        child: body,
-      );
-      // Excluding the subtree keeps the label from reading twice, but it
-      // drops the InkWell's tap action with it — the node re-owns
-      // activation or assistive tech can announce the pill yet not tap it.
-      body = Semantics(
-        button: true,
-        label: widget.label,
-        excludeSemantics: true,
-        onTap: enabled ? widget.onTap : null,
-        child: body,
-      );
-    } else if (!showLabel) {
-      // The inert icon-only body still announces the tool's name.
-      body = Semantics(
-        label: widget.label,
-        child: ExcludeSemantics(child: body),
-      );
-    }
-
-    // On the body only — the X carries its own tooltip, and covering it
-    // from an ancestor would raise both at once.
-    final tooltip = widget.tooltip;
-    if (tooltip != null) {
-      body = Tooltip(message: tooltip, child: body);
-    }
-
-    Widget? remove;
-    if (hasRemove) {
-      remove = InkWell(
-        onTap: enabled ? widget.onRemove : null,
-        onHover: enabled
-            ? (value) => setState(() => _removeHovered = value)
-            : null,
-        hoverColor: colors.surfaceContainerLow,
-        child: Padding(
-          padding: EdgeInsetsDirectional.only(
-            start: gap,
-            end: endInset,
-            top: resolved.top,
-            bottom: resolved.bottom,
-          ),
-          child: Center(
-            child: Icon(
-              Icons.close,
-              size: _removeSize,
-              color: removeForeground,
-            ),
-          ),
-        ),
-      );
-      // Tooltip already contributes the message to the semantics node, so
-      // it doubles as the X's accessible name — the circle button's idiom.
-      final removeTooltip = widget.removeTooltip;
-      if (removeTooltip != null) {
-        remove = Tooltip(message: removeTooltip, child: remove);
-      }
-    }
-
-    return Material(
+    // One control: the hover wash spans the whole pill and a tap anywhere
+    // on it fires the pill's action.
+    Widget pill = Material(
       color: colors.surfaceContainerLow,
       shape: shape,
       clipBehavior: Clip.antiAlias,
       child: SizedBox(
         height: _height,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          // Stretched, so the body's ink and the X's target span the
-          // pill's full height; each region centres its own glyphs.
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [body, ?remove],
-        ),
+        child: tapAction == null
+            ? content
+            : InkWell(
+                onTap: enabled ? tapAction : null,
+                onHover: enabled
+                    ? (value) => setState(() => _hovered = value)
+                    : null,
+                hoverColor: colors.surfaceContainer,
+                child: content,
+              ),
       ),
     );
+
+    // Excluding the subtree keeps the label from reading twice, but it
+    // drops the InkWell's tap action with it — the node re-owns
+    // activation or assistive tech could announce the pill yet not tap it.
+    if (tapAction != null) {
+      pill = Semantics(
+        button: true,
+        label: widget.label,
+        excludeSemantics: true,
+        onTap: enabled ? tapAction : null,
+        child: pill,
+      );
+    } else if (!showLabel) {
+      // The inert icon-only pill still announces the tool's name.
+      pill = Semantics(
+        label: widget.label,
+        child: ExcludeSemantics(child: pill),
+      );
+    }
+
+    // While removable, the removal name explains the whole pill's tap;
+    // otherwise the body tooltip carries the tool's name.
+    final tooltip = hasRemove
+        ? (widget.removeTooltip ?? widget.tooltip)
+        : widget.tooltip;
+    if (tooltip != null) {
+      pill = Tooltip(message: tooltip, child: pill);
+    }
+
+    return pill;
   }
 }


### PR DESCRIPTION
## What

Design-spec polish across three components, verified in the playground.

### FlowPill (+ composer)
- One control: the whole pill washes with `surfaceContainer` on hover and a tap anywhere reports `onRemove` — the X is the affordance, not a separate target. `onTap` still serves status pills without `onRemove`.
- Tool glyph rests in `onSurfaceVariant`; icon-only form keeps its 4px inner gap.
- Composer spaces adjacent pills 8px (6 on phones, theme-platform steered); other actions keep the row's 4px.

### FlowCodeBlock
- `surfaceContainerLowest` ground, `outlineVariant` hairline firming to `surfaceContainerHighest` on hover (fill stays put).
- Ruleless header: 16/12/10 insets, label in `bodySmall` `onSurfaceMuted`.
- Copy affordance at 14px, hover-revealed on pointer-driven desktop, always visible on phones (theme-platform steered) and while keyboard-focused.

### FlowErrorState
- Glyph (16px) inline left of the title, centred on the text's first line in both title and message-only forms; description and retry pill align to the card's left edge. Rhythm: icon·6·title, 8 to message, 12 to pill.

## Review notes

A multi-angle review ran over this diff; known follow-ups, none blocking per author call:
- a11y: hover-hidden copy button is absent from the semantics tree; removable pill announces the tool name while its tap removes; disabled pills lack the disabled flag.
- State: `_copyFocused`/pill hover can go stale on unmount/disable; error icon box ignores text scaling.
- `FlowPill.onTap` is silently ignored alongside `onRemove` (needs an assert); composer's pill gap type-check degrades under wrapped pills; is-mobile predicate and hover-capability machinery are now duplicated and worth extracting.

`flutter analyze` clean; no new dependencies; all colors/typography via theme tokens.