### PR TITLE
feat: retune the type scale and add title/label emphasis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.2.0 (unreleased)
 
+- **Typography** — title and label roles now carry an emphasised cut
+  (`titleLargeEmphasised` / `labelLargeEmphasised`, and the medium/small
+  pair for each). The standard scale sizes and line heights are retuned
+  to the design file: display at 1.15, headline at 1.2, title/label at
+  1.3. Compact `FlowGreeting` uses `titleMedium` instead of a one-off 21.
+- **Breaking**: constructing `FlowTypography(...)` now requires the new
+  title and label emphasised styles. `FlowTypography.standard` and
+  `copyWith` cover the usual host paths; label sizes also step up one
+  rung (16 / 14 / 12).
 - **Code block** — `FlowCodeBlock`, and a `FlowCodePart` message part
   rendered by `FlowMessage`/`FlowThread` with copy intent surfaced on
   `onCodeCopy`. Highlighting is built in and synchronous (Dart, JSON,

--- a/docs/src/content/docs/theming.mdx
+++ b/docs/src/content/docs/theming.mdx
@@ -93,16 +93,16 @@ Text(
 ## The type scale
 
 `FlowTypography.standard` follows the Material 3 scale — display, headline,
-title, body and label, each in large / medium / small — set in Figtree. Two
-habits of the design carry through the whole scale: no letter-spacing, and
-one of two line heights — 1.5 where text wraps into paragraphs, 1.3 where
-it sits on a single line in a control.
+title, body and label, each in large / medium / small — set in Figtree.
+Letter-spacing stays at zero. Line heights step with the role: 1.5 for
+body, 1.3 for title and label, 1.2 for headline, 1.15 for display.
 
-Each body size also carries three weights of ink — `bodyLarge`,
+Each body size carries three weights of ink — `bodyLarge`,
 `bodyLargeEmphasised` (w500), `bodyLargeDark` (w600), and likewise for
-Medium and Small — so emphasis inside a message never needs an ad-hoc
-`copyWith`. Styles are colorless; components pair them with color tokens at
-draw time.
+Medium and Small. Title and label pair the regular cut with an emphasised
+one (`titleLargeEmphasised` at w600, `labelLargeEmphasised` at w500), so
+emphasis in a heading or a control never needs an ad-hoc `copyWith`.
+Styles are colorless; components pair them with color tokens at draw time.
 
 To keep the scale and swap the face:
 

--- a/lib/src/theme/flow_typography.dart
+++ b/lib/src/theme/flow_typography.dart
@@ -51,8 +51,11 @@ class FlowTypography {
     required this.headlineMedium,
     required this.headlineSmall,
     required this.titleLarge,
+    required this.titleLargeEmphasised,
     required this.titleMedium,
+    required this.titleMediumEmphasised,
     required this.titleSmall,
+    required this.titleSmallEmphasised,
     required this.bodyLarge,
     required this.bodyLargeEmphasised,
     required this.bodyLargeDark,
@@ -63,8 +66,11 @@ class FlowTypography {
     required this.bodySmallEmphasised,
     required this.bodySmallDark,
     required this.labelLarge,
+    required this.labelLargeEmphasised,
     required this.labelMedium,
+    required this.labelMediumEmphasised,
     required this.labelSmall,
+    required this.labelSmallEmphasised,
     this.code = _standardCode,
     this.codeInline = _standardCodeInline,
   });
@@ -75,9 +81,15 @@ class FlowTypography {
   final TextStyle headlineLarge;
   final TextStyle headlineMedium;
   final TextStyle headlineSmall;
+
+  /// Headings — single-line at 1.3. Each size pairs the regular cut
+  /// (w400) with an emphasised one (w600).
   final TextStyle titleLarge;
+  final TextStyle titleLargeEmphasised;
   final TextStyle titleMedium;
+  final TextStyle titleMediumEmphasised;
   final TextStyle titleSmall;
+  final TextStyle titleSmallEmphasised;
 
   /// Prose and composer input — the design's 16/1.5 body.
   /// Each size carries three inks: regular (w400), emphasised (w500) and
@@ -92,10 +104,15 @@ class FlowTypography {
   final TextStyle bodySmallEmphasised;
   final TextStyle bodySmallDark;
 
-  /// Controls — the design's 14/1.3 label.
+  /// Controls — the design's 16/14/12 on the tight 1.3 line. Each size
+  /// pairs the regular cut (w400) with an emphasised one (w500), like the
+  /// body roles.
   final TextStyle labelLarge;
+  final TextStyle labelLargeEmphasised;
   final TextStyle labelMedium;
+  final TextStyle labelMediumEmphasised;
   final TextStyle labelSmall;
+  final TextStyle labelSmallEmphasised;
 
   /// Code, set in the bundled Geist Mono — the code block's body. A step
   /// under prose (13) on a taller line (1.6), so a block reads as inset
@@ -110,67 +127,87 @@ class FlowTypography {
     displayLarge: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 57,
+      fontSize: 52,
       fontWeight: FontWeight.w400,
       height: 1.15,
     ),
     displayMedium: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 45,
+      fontSize: 46,
       fontWeight: FontWeight.w400,
       height: 1.15,
     ),
     displaySmall: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 36,
+      fontSize: 40,
       fontWeight: FontWeight.w400,
-      height: 1.2,
+      height: 1.15,
     ),
     // The greeting: 32 regular at 1.3.
     headlineLarge: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 32,
+      fontSize: 36,
       fontWeight: FontWeight.w400,
-      height: 1.3,
+      height: 1.2,
     ),
     headlineMedium: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 28,
+      fontSize: 32,
       fontWeight: FontWeight.w400,
-      height: 1.3,
+      height: 1.2,
     ),
     headlineSmall: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 28,
+      fontWeight: FontWeight.w400,
+      height: 1.2,
+    ),
+    titleLarge: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
       fontSize: 24,
       fontWeight: FontWeight.w400,
       height: 1.3,
     ),
-    titleLarge: TextStyle(
+    titleLargeEmphasised: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 22,
+      fontSize: 24,
       fontWeight: FontWeight.w600,
       height: 1.3,
     ),
-    // A heading inside a message: 18 semibold at 1.5.
     titleMedium: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 18,
+      fontSize: 21,
+      fontWeight: FontWeight.w400,
+      height: 1.3,
+    ),
+    titleMediumEmphasised: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 21,
       fontWeight: FontWeight.w600,
-      height: 1.5,
+      height: 1.3,
     ),
     titleSmall: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 16,
+      fontSize: 18,
+      fontWeight: FontWeight.w400,
+      height: 1.3,
+    ),
+    titleSmallEmphasised: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 18,
       fontWeight: FontWeight.w600,
-      height: 1.4,
+      height: 1.3,
     ),
     bodyLarge: TextStyle(
       fontFamily: _fontFamily,
@@ -238,21 +275,42 @@ class FlowTypography {
     labelLarge: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 14,
+      fontSize: 16,
       fontWeight: FontWeight.w400,
+      height: 1.3,
+    ),
+    labelLargeEmphasised: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 16,
+      fontWeight: FontWeight.w500,
       height: 1.3,
     ),
     labelMedium: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 12,
+      fontSize: 14,
+      fontWeight: FontWeight.w400,
+      height: 1.3,
+    ),
+    labelMediumEmphasised: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 14,
       fontWeight: FontWeight.w500,
       height: 1.3,
     ),
     labelSmall: TextStyle(
       fontFamily: _fontFamily,
       package: _fontPackage,
-      fontSize: 11,
+      fontSize: 12,
+      fontWeight: FontWeight.w400,
+      height: 1.3,
+    ),
+    labelSmallEmphasised: TextStyle(
+      fontFamily: _fontFamily,
+      package: _fontPackage,
+      fontSize: 12,
       fontWeight: FontWeight.w500,
       height: 1.3,
     ),
@@ -284,8 +342,11 @@ class FlowTypography {
       headlineMedium: reface(headlineMedium),
       headlineSmall: reface(headlineSmall),
       titleLarge: reface(titleLarge),
+      titleLargeEmphasised: reface(titleLargeEmphasised),
       titleMedium: reface(titleMedium),
+      titleMediumEmphasised: reface(titleMediumEmphasised),
       titleSmall: reface(titleSmall),
+      titleSmallEmphasised: reface(titleSmallEmphasised),
       bodyLarge: reface(bodyLarge),
       bodyLargeEmphasised: reface(bodyLargeEmphasised),
       bodyLargeDark: reface(bodyLargeDark),
@@ -296,8 +357,11 @@ class FlowTypography {
       bodySmallEmphasised: reface(bodySmallEmphasised),
       bodySmallDark: reface(bodySmallDark),
       labelLarge: reface(labelLarge),
+      labelLargeEmphasised: reface(labelLargeEmphasised),
       labelMedium: reface(labelMedium),
+      labelMediumEmphasised: reface(labelMediumEmphasised),
       labelSmall: reface(labelSmall),
+      labelSmallEmphasised: reface(labelSmallEmphasised),
       code: code,
       codeInline: codeInline,
     );
@@ -328,8 +392,11 @@ class FlowTypography {
     TextStyle? headlineMedium,
     TextStyle? headlineSmall,
     TextStyle? titleLarge,
+    TextStyle? titleLargeEmphasised,
     TextStyle? titleMedium,
+    TextStyle? titleMediumEmphasised,
     TextStyle? titleSmall,
+    TextStyle? titleSmallEmphasised,
     TextStyle? bodyLarge,
     TextStyle? bodyLargeEmphasised,
     TextStyle? bodyLargeDark,
@@ -340,8 +407,11 @@ class FlowTypography {
     TextStyle? bodySmallEmphasised,
     TextStyle? bodySmallDark,
     TextStyle? labelLarge,
+    TextStyle? labelLargeEmphasised,
     TextStyle? labelMedium,
+    TextStyle? labelMediumEmphasised,
     TextStyle? labelSmall,
+    TextStyle? labelSmallEmphasised,
     TextStyle? code,
     TextStyle? codeInline,
   }) {
@@ -353,8 +423,12 @@ class FlowTypography {
       headlineMedium: headlineMedium ?? this.headlineMedium,
       headlineSmall: headlineSmall ?? this.headlineSmall,
       titleLarge: titleLarge ?? this.titleLarge,
+      titleLargeEmphasised: titleLargeEmphasised ?? this.titleLargeEmphasised,
       titleMedium: titleMedium ?? this.titleMedium,
+      titleMediumEmphasised:
+          titleMediumEmphasised ?? this.titleMediumEmphasised,
       titleSmall: titleSmall ?? this.titleSmall,
+      titleSmallEmphasised: titleSmallEmphasised ?? this.titleSmallEmphasised,
       bodyLarge: bodyLarge ?? this.bodyLarge,
       bodyLargeEmphasised: bodyLargeEmphasised ?? this.bodyLargeEmphasised,
       bodyLargeDark: bodyLargeDark ?? this.bodyLargeDark,
@@ -365,8 +439,12 @@ class FlowTypography {
       bodySmallEmphasised: bodySmallEmphasised ?? this.bodySmallEmphasised,
       bodySmallDark: bodySmallDark ?? this.bodySmallDark,
       labelLarge: labelLarge ?? this.labelLarge,
+      labelLargeEmphasised: labelLargeEmphasised ?? this.labelLargeEmphasised,
       labelMedium: labelMedium ?? this.labelMedium,
+      labelMediumEmphasised:
+          labelMediumEmphasised ?? this.labelMediumEmphasised,
       labelSmall: labelSmall ?? this.labelSmall,
+      labelSmallEmphasised: labelSmallEmphasised ?? this.labelSmallEmphasised,
       code: code ?? this.code,
       codeInline: codeInline ?? this.codeInline,
     );
@@ -382,8 +460,23 @@ class FlowTypography {
       headlineMedium: TextStyle.lerp(headlineMedium, other.headlineMedium, t)!,
       headlineSmall: TextStyle.lerp(headlineSmall, other.headlineSmall, t)!,
       titleLarge: TextStyle.lerp(titleLarge, other.titleLarge, t)!,
+      titleLargeEmphasised: TextStyle.lerp(
+        titleLargeEmphasised,
+        other.titleLargeEmphasised,
+        t,
+      )!,
       titleMedium: TextStyle.lerp(titleMedium, other.titleMedium, t)!,
+      titleMediumEmphasised: TextStyle.lerp(
+        titleMediumEmphasised,
+        other.titleMediumEmphasised,
+        t,
+      )!,
       titleSmall: TextStyle.lerp(titleSmall, other.titleSmall, t)!,
+      titleSmallEmphasised: TextStyle.lerp(
+        titleSmallEmphasised,
+        other.titleSmallEmphasised,
+        t,
+      )!,
       bodyLarge: TextStyle.lerp(bodyLarge, other.bodyLarge, t)!,
       bodyLargeEmphasised: TextStyle.lerp(
         bodyLargeEmphasised,
@@ -406,8 +499,23 @@ class FlowTypography {
       )!,
       bodySmallDark: TextStyle.lerp(bodySmallDark, other.bodySmallDark, t)!,
       labelLarge: TextStyle.lerp(labelLarge, other.labelLarge, t)!,
+      labelLargeEmphasised: TextStyle.lerp(
+        labelLargeEmphasised,
+        other.labelLargeEmphasised,
+        t,
+      )!,
       labelMedium: TextStyle.lerp(labelMedium, other.labelMedium, t)!,
+      labelMediumEmphasised: TextStyle.lerp(
+        labelMediumEmphasised,
+        other.labelMediumEmphasised,
+        t,
+      )!,
       labelSmall: TextStyle.lerp(labelSmall, other.labelSmall, t)!,
+      labelSmallEmphasised: TextStyle.lerp(
+        labelSmallEmphasised,
+        other.labelSmallEmphasised,
+        t,
+      )!,
       code: TextStyle.lerp(code, other.code, t)!,
       codeInline: TextStyle.lerp(codeInline, other.codeInline, t)!,
     );

--- a/lib/src/utils/flow_menu_core.dart
+++ b/lib/src/utils/flow_menu_core.dart
@@ -293,7 +293,7 @@ WidgetStatePropertyAll<Widget> flowSubmenuChevron(BuildContext context) {
 }
 
 /// Default row label style: the design's 14 Medium in the menu and
-/// 16 Medium in the sheet, both on the tight line height.
+/// 16 Medium in the sheet — the label roles' emphasised cuts.
 TextStyle flowMenuLabelStyle(
   BuildContext context, {
   required bool large,
@@ -301,8 +301,8 @@ TextStyle flowMenuLabelStyle(
 }) {
   final typography = context.flowTypography;
   final base = large
-      ? typography.bodyLarge.copyWith(fontWeight: FontWeight.w500, height: 1.3)
-      : typography.labelLarge.copyWith(fontWeight: FontWeight.w500);
+      ? typography.labelLargeEmphasised
+      : typography.labelMediumEmphasised;
   final override = style?.labelStyle;
   return override == null ? base : base.merge(override);
 }
@@ -312,7 +312,7 @@ TextStyle flowMenuDescriptionStyle(
   BuildContext context, {
   FlowMenuStyle? style,
 }) {
-  final base = context.flowTypography.labelLarge.copyWith(
+  final base = context.flowTypography.labelMedium.copyWith(
     color: context.flowColors.onSurfaceMuted,
   );
   final override = style?.descriptionStyle;

--- a/lib/src/utils/flow_menu_sheet.dart
+++ b/lib/src/utils/flow_menu_sheet.dart
@@ -159,10 +159,8 @@ class _FlowMenuSheetState extends State<_FlowMenuSheet> {
                       textAlign: TextAlign.center,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: context.flowTypography.bodyLarge.copyWith(
-                        fontWeight: FontWeight.w500,
-                        color: colors.onSurface,
-                      ),
+                      style: context.flowTypography.labelLargeEmphasised
+                          .copyWith(color: colors.onSurface),
                     ),
             ),
             // Balances the leading button so the title stays centered.

--- a/lib/src/widgets/flow_attachment_group.dart
+++ b/lib/src/widgets/flow_attachment_group.dart
@@ -481,7 +481,7 @@ class _TypePill extends StatelessWidget {
               padding: _pillPadding,
               child: Text(
                 kind,
-                style: context.flowTypography.labelMedium.copyWith(
+                style: context.flowTypography.labelSmall.copyWith(
                   color: colors.surfaceBright,
                   fontWeight: FontWeight.w600,
                 ),

--- a/lib/src/widgets/flow_attachment_preview.dart
+++ b/lib/src/widgets/flow_attachment_preview.dart
@@ -398,7 +398,7 @@ class _TopBar extends StatelessWidget {
                   label,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: typography.labelLarge.copyWith(
+                  style: typography.labelMedium.copyWith(
                     color: colors.onSurface,
                   ),
                 ),

--- a/lib/src/widgets/flow_error_state.dart
+++ b/lib/src/widgets/flow_error_state.dart
@@ -99,7 +99,7 @@ class FlowErrorState extends StatelessWidget {
     final below = title == null ? null : message;
 
     final rowStyle = title != null
-        ? typography.labelLarge.copyWith(
+        ? typography.labelMedium.copyWith(
             fontWeight: FontWeight.w600,
             color: colors.onSurface,
           )
@@ -239,7 +239,7 @@ class _RetryButtonState extends State<_RetryButton> {
                   const SizedBox(width: _glyphGap),
                   Text(
                     label,
-                    style: typography.labelLarge.copyWith(
+                    style: typography.labelMedium.copyWith(
                       fontWeight: FontWeight.w600,
                       color: foreground,
                     ),

--- a/lib/src/widgets/flow_greeting.dart
+++ b/lib/src/widgets/flow_greeting.dart
@@ -35,19 +35,17 @@ class FlowGreeting extends StatelessWidget {
   /// accent in the glyph in both themes.
   final Color? iconColor;
 
-  /// Defaults to `headlineLarge` in the row form, and the same style at the
-  /// design's 21 in the stacked form. An explicit style is used as given in
-  /// both.
+  /// Defaults to `headlineLarge` in the row form and `titleMedium` in the
+  /// stacked form. An explicit style is used as given in both.
   final TextStyle? textStyle;
 
-  /// The design's title: a 40px glyph, beside 32px text on wide screens —
-  /// 16 apart, bottom-aligned — and above 21px text on compact ones, 4
-  /// apart. The 21 sits between the type scale's steps, so it stays here as
-  /// drawn. Compact begins below 600, Material's compact/medium boundary.
+  /// The design's title: a 40px glyph, beside headline text on wide
+  /// screens — 16 apart, bottom-aligned — and above title text on compact
+  /// ones, 4 apart. Compact begins below 600, Material's compact/medium
+  /// boundary.
   static const double _iconSize = 40;
   static const double _wideGap = 16;
   static const double _narrowGap = 4;
-  static const double _narrowFontSize = 21;
   static const double _compactBreakpoint = 600;
 
   @override
@@ -57,12 +55,11 @@ class FlowGreeting extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final compact = constraints.maxWidth < _compactBreakpoint;
+        final typography = context.flowTypography;
         final style =
             textStyle ??
-            context.flowTypography.headlineLarge.copyWith(
-              color: colors.onSurface,
-              fontSize: compact ? _narrowFontSize : null,
-            );
+            (compact ? typography.titleMedium : typography.headlineLarge)
+                .copyWith(color: colors.onSurface);
         final label = Text(text, style: style, textAlign: TextAlign.center);
         if (icon == null) return label;
 

--- a/lib/src/widgets/flow_menu_style.dart
+++ b/lib/src/widgets/flow_menu_style.dart
@@ -62,11 +62,11 @@ class FlowMenuStyle {
   /// Row fill on hover and focus. Defaults to `surfaceContainer`.
   final Color? hoverColor;
 
-  /// Merged over the default row label style (`labelLarge` at weight 500 in
-  /// the menu, `bodyLarge` at weight 500 in the sheet).
+  /// Merged over the default row label style (`labelMediumEmphasised` in
+  /// the menu, `labelLargeEmphasised` in the sheet).
   final TextStyle? labelStyle;
 
-  /// Merged over the default description style (`labelLarge` in
+  /// Merged over the default description style (`labelMedium` in
   /// `onSurfaceMuted`).
   final TextStyle? descriptionStyle;
 

--- a/lib/src/widgets/flow_model_selector.dart
+++ b/lib/src/widgets/flow_model_selector.dart
@@ -385,7 +385,7 @@ class _FlowModelSelectorState extends State<FlowModelSelector> {
                 children: [
                   Text(
                     _selected?.label ?? '',
-                    style: context.flowTypography.labelLarge.copyWith(
+                    style: context.flowTypography.labelMedium.copyWith(
                       color: labelColor,
                     ),
                   ),
@@ -393,7 +393,7 @@ class _FlowModelSelectorState extends State<FlowModelSelector> {
                     const SizedBox(width: _gap),
                     Text(
                       effort.label,
-                      style: context.flowTypography.labelLarge.copyWith(
+                      style: context.flowTypography.labelMedium.copyWith(
                         color: effortForeground,
                       ),
                     ),

--- a/lib/src/widgets/flow_pill.dart
+++ b/lib/src/widgets/flow_pill.dart
@@ -170,8 +170,7 @@ class _FlowPillState extends State<FlowPill> {
             const SizedBox(width: _gap),
             Text(
               widget.label,
-              style: typography.labelLarge.copyWith(
-                fontWeight: FontWeight.w500,
+              style: typography.labelMediumEmphasised.copyWith(
                 color: labelForeground,
               ),
             ),

--- a/lib/src/widgets/flow_suggestion.dart
+++ b/lib/src/widgets/flow_suggestion.dart
@@ -132,8 +132,7 @@ class _FlowSuggestionState extends State<FlowSuggestion> {
                   widget.label,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: context.flowTypography.bodyLarge.copyWith(
-                    height: 1.3,
+                  style: context.flowTypography.labelLarge.copyWith(
                     color: foreground,
                   ),
                 );

--- a/playground/ios/Podfile.lock
+++ b/playground/ios/Podfile.lock
@@ -1,0 +1,28 @@
+PODS:
+  - Flutter (1.0.0)
+  - irondash_engine_context (0.0.1):
+    - Flutter
+  - super_native_extensions (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - irondash_engine_context (from `.symlinks/plugins/irondash_engine_context/ios`)
+  - super_native_extensions (from `.symlinks/plugins/super_native_extensions/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  irondash_engine_context:
+    :path: ".symlinks/plugins/irondash_engine_context/ios"
+  super_native_extensions:
+    :path: ".symlinks/plugins/super_native_extensions/ios"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  irondash_engine_context: 8e58ca8e0212ee9d1c7dc6a42121849986c88486
+  super_native_extensions: b763c02dc3a8fd078389f410bf15149179020cb4
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/playground/ios/Runner.xcodeproj/project.pbxproj
+++ b/playground/ios/Runner.xcodeproj/project.pbxproj
@@ -8,8 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1A23FC47FFA8BA57C061F349 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66534AA1D9592FE2E804959D /* Pods_Runner.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		609C4EDB484463726AD949CE /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 907E1777A618584DC397EFA5 /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -42,16 +44,22 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1328C3974F32076DF177DEA1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1CBA0FA26D7E8E6A4EA4AB40 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3BF4C6FB4A935A4866399818 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		44F98BE2B881F3BD4E54F641 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		66534AA1D9592FE2E804959D /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		907E1777A618584DC397EFA5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -59,6 +67,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ADD21A35A3EC1F26BE195030 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		FB1666477910771EC7A1713D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,18 +77,50 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				1A23FC47FFA8BA57C061F349 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9C93D0046B61E120ABF74D06 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				609C4EDB484463726AD949CE /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		131621EB0950BB1F333E0CE9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				66534AA1D9592FE2E804959D /* Pods_Runner.framework */,
+				907E1777A618584DC397EFA5 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		96712A26F91724380CCAC3D4 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				3BF4C6FB4A935A4866399818 /* Pods-Runner.debug.xcconfig */,
+				44F98BE2B881F3BD4E54F641 /* Pods-Runner.release.xcconfig */,
+				1328C3974F32076DF177DEA1 /* Pods-Runner.profile.xcconfig */,
+				1CBA0FA26D7E8E6A4EA4AB40 /* Pods-RunnerTests.debug.xcconfig */,
+				ADD21A35A3EC1F26BE195030 /* Pods-RunnerTests.release.xcconfig */,
+				FB1666477910771EC7A1713D /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -100,6 +142,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				96712A26F91724380CCAC3D4 /* Pods */,
+				131621EB0950BB1F333E0CE9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -135,8 +179,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				E175659BE70E0D691ED0D55E /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				9C93D0046B61E120ABF74D06 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -152,12 +198,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				3C2929824FA3F89B43F0A46D /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				416F1EFE41CE761BB5B10BC3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -201,7 +249,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -251,6 +299,45 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		3C2929824FA3F89B43F0A46D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		416F1EFE41CE761BB5B10BC3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -265,6 +352,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E175659BE70E0D691ED0D55E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -393,6 +502,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CBA0FA26D7E8E6A4EA4AB40 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +520,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ADD21A35A3EC1F26BE195030 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -425,6 +536,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FB1666477910771EC7A1713D /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -630,7 +742,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/playground/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/playground/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## Summary

Retunes `FlowTypography.standard` to the design file and adds emphasised cuts for title and label, then points existing controls at those roles instead of ad-hoc `copyWith` weights.

- Display / headline / title / label sizes and line heights match the design: display at 1.15, headline at 1.2, title and label at 1.3.
- New public styles: `titleLargeEmphasised`, `titleMediumEmphasised`, `titleSmallEmphasised`, `labelLargeEmphasised`, `labelMediumEmphasised`, `labelSmallEmphasised`.
- Compact `FlowGreeting` uses `titleMedium` instead of a one-off 21px override.
- Menus, sheets, pills, suggestions, model selector, error state, and attachment chrome consume the new roles.

**Breaking:** constructing `FlowTypography(...)` now requires the new emphasised styles. `FlowTypography.standard` and `copyWith` cover the usual host paths. Label sizes also step up one rung (16 / 14 / 12).

## Screenshots

Visual change is type size/weight across greeting, menus, pills, suggestions, and error chrome. Screenshots from the playground stages to follow.

| Before | After |
| --- | --- |
|  |  |

## How this was verified

- Playground stages that consume the retuned roles: greeting, menus / model selector, pill, suggestions, error state, attachments.
- `dart format` on the changed Dart files.

## Checklist

- [ ] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [ ] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] No new entries under `dependencies:` in `pubspec.yaml` (Flutter SDK and flutter.dev packages only)
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [ ] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

Made with [Cursor](https://cursor.com)