### PR TITLE
chore: remove unused contact links from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: 📚 Documentation
-    url: https://flowui.stac.dev/
-    about: Component guides, theming, and the API surface.
-  - name: 🧩 Playground
-    url: https://flowui.stac.dev/playground
-    about: Reproduce it live against the latest build — every component has a stage with variant pills and code snippets.
-  - name: 🗺️ Roadmap
-    url: https://flowui.stac.dev/roadmap
-    about: Check whether the component you want is already planned.
-  - name: 🤓 API reference
-    url: https://pub.dev/documentation/flow_ui/latest/
-    about: Generated dartdoc for every public widget and token.


### PR DESCRIPTION
## Summary

<!-- What changes, and why. Link the issue it closes: Closes #123 -->

## Screenshots

<!-- flow_ui is a UI library, so anything visual needs a picture. Delete this
     section only if the change renders nothing. -->

| Before | After |
| --- | --- |
|  |  |

## How this was verified

<!-- Which playground stages you exercised, on which platforms (and both
     themes, if the change touches colour). -->

## Checklist

- [ ] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [ ] `dart format .` applied
- [ ] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [ ] No new entries under `dependencies:` in `pubspec.yaml` (Flutter SDK and flutter.dev packages only)
- [ ] Nothing model-facing — no prompts, schemas, or provider/network calls
- [ ] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [ ] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [ ] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub issue-form metadata only; no application, security, or runtime behavior changes.
> 
> **Overview**
> Removes the GitHub issue `contact_links` (docs, playground, roadmap, API reference) from `.github/ISSUE_TEMPLATE/config.yml`, leaving only `blank_issues_enabled: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a6f059e65ff9401f77852ddbc735b258c8cf8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->