### PR TITLE
fix: absorb the safe area into the chat view's bottom inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.3.0 (unreleased)
 
+- **Fix** — `FlowChatView`'s bottom inset no longer stacks on the safe
+  area. The design's 24 (compact) and 40 (wide) are now measured from the
+  bottom of the safe area, so a phone's home indicator is absorbed rather
+  than added to — a device showed 58 where the design draws 24. Simulated
+  frames and desktop, which report no inset, are unchanged, and the full
+  inset returns above an open keyboard.
+
 - **Component styles** — Material's component-theme tier, on flow_ui's
   tokens: every major widget now takes an optional style object of
   color and text overrides (`FlowComposerStyle`, `FlowMessageStyle`,

--- a/lib/src/widgets/flow_chat_view.dart
+++ b/lib/src/widgets/flow_chat_view.dart
@@ -144,7 +144,9 @@ class FlowChatView extends StatefulWidget {
   /// Around the composer block. Defaults to the design's 16 at the sides —
   /// kept *outside* [maxContentWidth], so the composer still reaches the
   /// full rail where there is room — with 40 below on wide layouts and 24
-  /// on compact ones. An explicit value is used as given on both.
+  /// on compact ones, measured from the bottom of the safe area so a home
+  /// indicator's inset is absorbed rather than added to. An explicit value
+  /// is used as given on both, safe area included.
   final EdgeInsetsGeometry? padding;
 
   @override
@@ -250,6 +252,12 @@ class _FlowChatViewState extends State<FlowChatView> {
 
   @override
   Widget build(BuildContext context) {
+    // Read above the SafeArea below, which consumes this padding: inside it
+    // the value always reads zero. It is also the *applied* inset rather
+    // than viewPadding, so it correctly drops to zero when the keyboard
+    // covers the home indicator.
+    final safeBottom = MediaQuery.paddingOf(context).bottom;
+
     return GestureDetector(
       // Taps that reach the surface itself — dead space, the thread, a
       // settled message — dismiss the keyboard, the chat convention.
@@ -292,7 +300,7 @@ class _FlowChatViewState extends State<FlowChatView> {
                           )
                         : _threadArea(context),
                   ),
-                  ..._composerZone(compact),
+                  ..._composerZone(compact, safeBottom),
                 ],
               ],
             );
@@ -438,7 +446,7 @@ class _FlowChatViewState extends State<FlowChatView> {
   /// content rail, inside the surface padding. Skipped entirely when there
   /// is nothing to put below the thread, so a read-only surface doesn't
   /// carry a strip of padding where its composer would have been.
-  List<Widget> _composerZone(bool compact) {
+  List<Widget> _composerZone(bool compact, double safeBottom) {
     final suggestions = widget.empty ? widget.suggestions : null;
     if (widget.composer == null &&
         widget.aboveComposer == null &&
@@ -446,13 +454,19 @@ class _FlowChatViewState extends State<FlowChatView> {
       return const [];
     }
 
+    // The design's inset measures from the bottom of the *safe* area, so
+    // it absorbs the home indicator's inset rather than stacking on top of
+    // it — a phone would otherwise stand the composer 24 above a 34pt
+    // indicator, which reads as a gap the design never drew. Simulated
+    // phone frames report no inset and keep the full 24.
+    final designBottom = compact ? _bottomInsetCompact : _bottomInsetWide;
     final padding =
         widget.padding ??
         EdgeInsetsDirectional.fromSTEB(
           _sideInset,
           0,
           _sideInset,
-          compact ? _bottomInsetCompact : _bottomInsetWide,
+          math.max(0, designBottom - safeBottom),
         );
 
     final column = <Widget>[];


### PR DESCRIPTION
## Summary

`FlowChatView` wraps its surface in a `SafeArea` and *also* adds the design's bottom inset below the composer, so on a real phone the two stack: 34pt of home indicator plus 24pt of padding, 58pt of dead space where the design draws 24. The playground's mobile frame is a narrow web viewport that reports no safe-area inset, so it only ever showed the 24 and looked right — which is why this survived until someone ran the example on a device.

The design's inset is now measured from the bottom of the *safe* area rather than added on top of it: `max(0, designBottom - safeBottom)`.

Two details are load-bearing:

- The inset is read in `build()`, above the `SafeArea` that consumes it. Inside that subtree `MediaQuery.paddingOf` always reads zero.
- It reads the *applied* padding rather than `viewPadding`. When the keyboard is up it covers the home indicator and the platform reports the applied inset as zero, so the full 24 correctly returns above the keyboard. A `viewPadding` version would have collapsed that to nothing and left the composer flush against the keyboard.

An explicit `padding:` override still wins as given, safe area included, and the doc comment now says so.

## Screenshots

| Before (device) | After (device) |
| --- | --- |
|  |  |

## How this was verified

`flutter analyze` and `dart format` clean. Behaviour measured in a scratch widget test across all three states, driving the view's real insets rather than a hand-built MediaQuery:

| Context | Before | After |
| --- | --- | --- |
| No inset (web, simulated frame, desktop) | 24 | 24 — unchanged |
| Home indicator, 34 | 58 | 34 |
| Keyboard open over the indicator | 24 | 24 — unchanged |

The test was confirmed to catch the regression: temporarily restoring the old expression fails it with `Actual: <58.0>`. The tests are not included here — `test/` in this repo is deliberately empty while the component surface is still being reshaped.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] No new entries under `dependencies:` in `pubspec.yaml` (Flutter SDK and flutter.dev packages only)
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout math for composer padding in FlowChatView with no auth, data, or API surface changes.
> 
> **Overview**
> **FlowChatView** no longer stacks the design’s bottom spacing on top of the device safe area. Default composer padding now uses **`max(0, designBottom − safeBottom)`** (24 compact / 40 wide from the safe-area edge), so a home indicator is counted toward that inset instead of adding extra gap (e.g. 58pt vs 24pt on device).
> 
> **`build()`** reads **`MediaQuery.paddingOf(context).bottom`** above the inner **`SafeArea`** (where that value is zero) and uses **applied** padding—not **`viewPadding`**—so when the keyboard covers the indicator the full design bottom inset returns. Web/simulated frames with no inset stay at 24/40; explicit **`padding:`** is unchanged and still includes safe area. Docs and **`CHANGELOG.md`** describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85aee6baeee4bbe50f08282489b1f38fa89327f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->