### PR TITLE
fix: focus the composer's field from a click anywhere on the card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,13 @@
   inline-code chip, quote, table and rule inks. All additive — nothing
   breaks.
 
+- **Fix** — the composer's card is now the field's hit target: a click on
+  its padding, the gap under the field or the empty stretch of the action
+  row focuses the field, and the pointer shows the text cursor over all of
+  it. Before, only the field's own text run took the click, so a card
+  with a short draft was mostly dead space. The buttons, the tiles and
+  the host's actions keep their own taps and cursors.
+
 ## 0.2.0
 
 - **Typography** — title and label roles now carry an emphasised cut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,6 @@
   markdown surface per element: heading cuts, the link color, the
   inline-code chip, quote, table and rule inks. All additive — nothing
   breaks.
-
 - **Fix** — the composer's card is now the field's hit target: a click on
   its padding, the gap under the field or the empty stretch of the action
   row focuses the field, and the pointer shows the text cursor over all of

--- a/docs/src/content/docs/components/composer.mdx
+++ b/docs/src/content/docs/components/composer.mdx
@@ -14,7 +14,9 @@ generating, and slots for host actions on the design's rail. `onSend` is
 required — a composer needs somewhere to send to. The card sits on
 `surfaceBright` behind a gradient hairline that firms on hover and focus,
 standing at the design's 116px with an empty draft — which also drains the
-send disc to the disabled ink.
+send disc to the disabled ink. The whole card is the field's click target:
+a click anywhere on it that is not a control focuses the field, and the
+pointer reads as a text cursor over all of it.
 
 ## Composed
 

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -416,13 +416,6 @@ class _FlowComposerState extends State<FlowComposer> {
   TextEditingController? _internalController;
   FocusNode? _internalFocusNode;
   late FocusNode _attachedFocusNode;
-
-  /// The field's tap-region group, widened to the whole card. The field
-  /// drops focus on a pointer *down* outside its region (desktop, web,
-  /// and any mouse press), so without this a click on the card's padding
-  /// would blur on the down and refocus on the up — cancelling IME
-  /// composition and firing the host's focus listeners twice on the way.
-  final Object _tapGroup = Object();
   bool _focused = false;
   bool _hovered = false;
   bool _attachHovered = false;
@@ -886,8 +879,15 @@ class _FlowComposerState extends State<FlowComposer> {
         cursor: widget.enabled
             ? SystemMouseCursors.text
             : SystemMouseCursors.basic,
-        child: TapRegion(
-          groupId: _tapGroup,
+        // The card joins the field's tap region. The field drops focus on a
+        // pointer *down* outside its region (desktop, web, and any mouse
+        // press), so without this a click on the padding would blur on the
+        // down and refocus on the up — cancelling IME composition and firing
+        // the host's focus listeners twice. It has to be the field's *default*
+        // group, not a private one: the selection handles and the Copy/Paste
+        // toolbar live in that default group, and a field moved out of it
+        // would blur on a press on its own toolbar.
+        child: TextFieldTapRegion(
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: widget.enabled ? _focusNode.requestFocus : null,
@@ -974,7 +974,6 @@ class _FlowComposerState extends State<FlowComposer> {
                           child: TextField(
                             controller: _controller,
                             focusNode: _focusNode,
-                            groupId: _tapGroup,
                             enabled: widget.enabled,
                             minLines: 1,
                             maxLines: widget.maxLines,

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -865,158 +865,181 @@ class _FlowComposerState extends State<FlowComposer> {
       child: MouseRegion(
         onEnter: (_) => setState(() => _hovered = true),
         onExit: (_) => setState(() => _hovered = false),
-        child: CustomPaint(
-          // The outline is painted rather than a layout border so the card
-          // never shifts as it swaps between its rest and active gradients.
-          foregroundPainter: FlowGradientOutlinePainter(
-            radius: radius,
-            start: _dropHover
-                ? highlight
-                : outline ??
-                      colors.onSurface.withValues(
-                        alpha: active ? _outlineActiveAlpha : _outlineRestAlpha,
-                      ),
-            end: _dropHover
-                ? highlight
-                : outline ??
-                      colors.onSurface.withValues(
-                        alpha: active
-                            ? _outlineActiveFadeAlpha
-                            : _outlineRestFadeAlpha,
-                      ),
-          ),
-          child: Container(
-            decoration: BoxDecoration(
-              // The composer is the design's raised card: it sits above the
-              // page rather than tinting it, in both themes, under a
-              // barely-there ambient lift. The drop wash blends into the
-              // ground rather than layering over it, so the card stays the
-              // one opaque surface even while lit.
-              color: _dropHover
-                  ? Color.alphaBlend(
-                      highlight.withValues(alpha: _dropWashAlpha),
-                      ground,
-                    )
-                  : ground,
-              borderRadius: radius,
-              boxShadow: [
-                BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
-              ],
+        // The whole card is the field's hit target: a click on the padding,
+        // the gap under the field or the empty stretch of the action row
+        // brings the caret in, as it would on a plain text box, and the
+        // pointer reads as a text cursor over all of it to say so. The
+        // buttons, the tiles and the field itself sit deeper in the tree,
+        // so their own taps still win the arena and their own cursors
+        // still show.
+        cursor: widget.enabled
+            ? SystemMouseCursors.text
+            : SystemMouseCursors.basic,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: widget.enabled ? _focusNode.requestFocus : null,
+          child: CustomPaint(
+            // The outline is painted rather than a layout border so the
+            // card never shifts as it swaps between its rest and active
+            // gradients.
+            foregroundPainter: FlowGradientOutlinePainter(
+              radius: radius,
+              start: _dropHover
+                  ? highlight
+                  : outline ??
+                        colors.onSurface.withValues(
+                          alpha: active
+                              ? _outlineActiveAlpha
+                              : _outlineRestAlpha,
+                        ),
+              end: _dropHover
+                  ? highlight
+                  : outline ??
+                        colors.onSurface.withValues(
+                          alpha: active
+                              ? _outlineActiveFadeAlpha
+                              : _outlineRestFadeAlpha,
+                        ),
             ),
-            padding: widget.padding ?? _cardPadding,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                if (widget.attachments.isNotEmpty) ...[
-                  // The inset rides inside the strip's scroll view rather
-                  // than around it: at rest nothing moves, but once the
-                  // strip overflows the tiles scroll under the gutter and
-                  // the last one is cut at the card's edge — the cue that
-                  // there is more, with no counter to draw.
-                  FlowAttachmentGroup(
-                    attachments: widget.attachments,
+            child: Container(
+              decoration: BoxDecoration(
+                // The composer is the design's raised card: it sits above the
+                // page rather than tinting it, in both themes, under a
+                // barely-there ambient lift. The drop wash blends into the
+                // ground rather than layering over it, so the card stays the
+                // one opaque surface even while lit.
+                color: _dropHover
+                    ? Color.alphaBlend(
+                        highlight.withValues(alpha: _dropWashAlpha),
+                        ground,
+                      )
+                    : ground,
+                borderRadius: radius,
+                boxShadow: [
+                  BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
+                ],
+              ),
+              padding: widget.padding ?? _cardPadding,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (widget.attachments.isNotEmpty) ...[
+                    // The inset rides inside the strip's scroll view rather
+                    // than around it: at rest nothing moves, but once the
+                    // strip overflows the tiles scroll under the gutter and
+                    // the last one is cut at the card's edge — the cue that
+                    // there is more, with no counter to draw.
+                    FlowAttachmentGroup(
+                      attachments: widget.attachments,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: _contentInset,
+                      ),
+                      onTap: widget.onAttachmentTap,
+                      // Editing is what `enabled` gates; viewing an attachment
+                      // that is already pending stays available, as does the
+                      // send button while streaming.
+                      onRemove: widget.enabled
+                          ? widget.onRemoveAttachment
+                          : null,
+                      removeTooltip: widget.removeAttachmentTooltip,
+                      previewCloseTooltip: widget.previewCloseTooltip,
+                    ),
+                    const SizedBox(height: _attachmentGap),
+                  ],
+                  Padding(
                     padding: const EdgeInsets.symmetric(
                       horizontal: _contentInset,
                     ),
-                    onTap: widget.onAttachmentTap,
-                    // Editing is what `enabled` gates; viewing an attachment
-                    // that is already pending stays available, as does the
-                    // send button while streaming.
-                    onRemove: widget.enabled ? widget.onRemoveAttachment : null,
-                    removeTooltip: widget.removeAttachmentTooltip,
-                    previewCloseTooltip: widget.previewCloseTooltip,
-                  ),
-                  const SizedBox(height: _attachmentGap),
-                ],
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: _contentInset,
-                  ),
-                  child: Container(
-                    constraints: const BoxConstraints(
-                      minHeight: _fieldMinHeight,
-                    ),
-                    alignment: AlignmentDirectional.topStart,
-                    child: Focus(
-                      onKeyEvent: _handleKeyEvent,
-                      child: TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        enabled: widget.enabled,
-                        minLines: 1,
-                        maxLines: widget.maxLines,
-                        // The design's compressed composer: body face on
-                        // the 1.3 control line, so the empty card stands
-                        // at 116.
-                        style: typography.bodyLarge
-                            .copyWith(height: 1.3, color: colors.onSurface)
-                            .merge(style?.textStyle),
-                        // Android's IME rich-content path, the one media
-                        // input the SDK covers without a plugin.
-                        contentInsertionConfiguration:
-                            widget.onContentInserted == null ||
-                                !widget.attachmentsEnabled
-                            ? null
-                            : ContentInsertionConfiguration(
-                                onContentInserted: widget.onContentInserted!,
-                              ),
-                        decoration: InputDecoration(
-                          isDense: true,
-                          border: InputBorder.none,
-                          hintText: widget.placeholder,
-                          hintStyle: typography.bodyLarge.copyWith(
-                            height: 1.3,
-                            color: style?.hintColor ?? colors.onSurfaceMuted,
+                    child: Container(
+                      constraints: const BoxConstraints(
+                        minHeight: _fieldMinHeight,
+                      ),
+                      alignment: AlignmentDirectional.topStart,
+                      child: Focus(
+                        onKeyEvent: _handleKeyEvent,
+                        child: TextField(
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          enabled: widget.enabled,
+                          minLines: 1,
+                          maxLines: widget.maxLines,
+                          // The design's compressed composer: body face on
+                          // the 1.3 control line, so the empty card stands
+                          // at 116.
+                          style: typography.bodyLarge
+                              .copyWith(height: 1.3, color: colors.onSurface)
+                              .merge(style?.textStyle),
+                          // Android's IME rich-content path, the one media
+                          // input the SDK covers without a plugin.
+                          contentInsertionConfiguration:
+                              widget.onContentInserted == null ||
+                                  !widget.attachmentsEnabled
+                              ? null
+                              : ContentInsertionConfiguration(
+                                  onContentInserted: widget.onContentInserted!,
+                                ),
+                          decoration: InputDecoration(
+                            isDense: true,
+                            border: InputBorder.none,
+                            hintText: widget.placeholder,
+                            hintStyle: typography.bodyLarge.copyWith(
+                              height: 1.3,
+                              color: style?.hintColor ?? colors.onSurfaceMuted,
+                            ),
+                            contentPadding: EdgeInsets.zero,
                           ),
-                          contentPadding: EdgeInsets.zero,
                         ),
                       ),
                     ),
                   ),
-                ),
-                const SizedBox(height: _fieldGap),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: _actionInset),
-                  child: Row(
-                    children: [
-                      // The built-in attach affordance leads the row; being
-                      // outside the loop keeps the pill-pair gap logic
-                      // reading only the host's actions.
-                      if (widget.attachmentsEnabled &&
-                          (widget.onAttach != null ||
-                              widget.onAttachmentsPicked != null)) ...[
-                        _buildAttachButton(context),
-                        const SizedBox(width: _leadingGap),
+                  const SizedBox(height: _fieldGap),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: _actionInset,
+                    ),
+                    child: Row(
+                      children: [
+                        // The built-in attach affordance leads the row; being
+                        // outside the loop keeps the pill-pair gap logic
+                        // reading only the host's actions.
+                        if (widget.attachmentsEnabled &&
+                            (widget.onAttach != null ||
+                                widget.onAttachmentsPicked != null)) ...[
+                          _buildAttachButton(context),
+                          const SizedBox(width: _leadingGap),
+                        ],
+                        for (
+                          var i = 0;
+                          i < widget.leadingActions.length;
+                          i++
+                        ) ...[
+                          widget.leadingActions[i],
+                          // Two neighbouring pills read as a set and take the
+                          // design's wider step — 8, closing to 6 on phones —
+                          // while everything else keeps the action row's 4.
+                          SizedBox(
+                            width:
+                                i + 1 < widget.leadingActions.length &&
+                                    widget.leadingActions[i] is FlowPill &&
+                                    widget.leadingActions[i + 1] is FlowPill
+                                ? (_isMobile(context)
+                                      ? _mobilePillGap
+                                      : _pillGap)
+                                : _leadingGap,
+                          ),
+                        ],
+                        const Spacer(),
+                        for (final action in widget.trailingActions) ...[
+                          action,
+                          const SizedBox(width: _trailingGap),
+                        ],
+                        _buildSendStopButton(context),
                       ],
-                      for (
-                        var i = 0;
-                        i < widget.leadingActions.length;
-                        i++
-                      ) ...[
-                        widget.leadingActions[i],
-                        // Two neighbouring pills read as a set and take the
-                        // design's wider step — 8, closing to 6 on phones —
-                        // while everything else keeps the action row's 4.
-                        SizedBox(
-                          width:
-                              i + 1 < widget.leadingActions.length &&
-                                  widget.leadingActions[i] is FlowPill &&
-                                  widget.leadingActions[i + 1] is FlowPill
-                              ? (_isMobile(context) ? _mobilePillGap : _pillGap)
-                              : _leadingGap,
-                        ),
-                      ],
-                      const Spacer(),
-                      for (final action in widget.trailingActions) ...[
-                        action,
-                        const SizedBox(width: _trailingGap),
-                      ],
-                      _buildSendStopButton(context),
-                    ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -414,6 +414,13 @@ class _FlowComposerState extends State<FlowComposer> {
   TextEditingController? _internalController;
   FocusNode? _internalFocusNode;
   late FocusNode _attachedFocusNode;
+
+  /// The field's tap-region group, widened to the whole card. The field
+  /// drops focus on a pointer *down* outside its region (desktop, web,
+  /// and any mouse press), so without this a click on the card's padding
+  /// would blur on the down and refocus on the up — cancelling IME
+  /// composition and firing the host's focus listeners twice on the way.
+  final Object _tapGroup = Object();
   bool _focused = false;
   bool _hovered = false;
   bool _attachHovered = false;
@@ -875,170 +882,176 @@ class _FlowComposerState extends State<FlowComposer> {
         cursor: widget.enabled
             ? SystemMouseCursors.text
             : SystemMouseCursors.basic,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: widget.enabled ? _focusNode.requestFocus : null,
-          child: CustomPaint(
-            // The outline is painted rather than a layout border so the
-            // card never shifts as it swaps between its rest and active
-            // gradients.
-            foregroundPainter: FlowGradientOutlinePainter(
-              radius: radius,
-              start: _dropHover
-                  ? highlight
-                  : outline ??
-                        colors.onSurface.withValues(
-                          alpha: active
-                              ? _outlineActiveAlpha
-                              : _outlineRestAlpha,
-                        ),
-              end: _dropHover
-                  ? highlight
-                  : outline ??
-                        colors.onSurface.withValues(
-                          alpha: active
-                              ? _outlineActiveFadeAlpha
-                              : _outlineRestFadeAlpha,
-                        ),
-            ),
-            child: Container(
-              decoration: BoxDecoration(
-                // The composer is the design's raised card: it sits above the
-                // page rather than tinting it, in both themes, under a
-                // barely-there ambient lift. The drop wash blends into the
-                // ground rather than layering over it, so the card stays the
-                // one opaque surface even while lit.
-                color: _dropHover
-                    ? Color.alphaBlend(
-                        highlight.withValues(alpha: _dropWashAlpha),
-                        ground,
-                      )
-                    : ground,
-                borderRadius: radius,
-                boxShadow: [
-                  BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
-                ],
+        child: TapRegion(
+          groupId: _tapGroup,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.enabled ? _focusNode.requestFocus : null,
+            child: CustomPaint(
+              // The outline is painted rather than a layout border so the
+              // card never shifts as it swaps between its rest and active
+              // gradients.
+              foregroundPainter: FlowGradientOutlinePainter(
+                radius: radius,
+                start: _dropHover
+                    ? highlight
+                    : outline ??
+                          colors.onSurface.withValues(
+                            alpha: active
+                                ? _outlineActiveAlpha
+                                : _outlineRestAlpha,
+                          ),
+                end: _dropHover
+                    ? highlight
+                    : outline ??
+                          colors.onSurface.withValues(
+                            alpha: active
+                                ? _outlineActiveFadeAlpha
+                                : _outlineRestFadeAlpha,
+                          ),
               ),
-              padding: widget.padding ?? _cardPadding,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (widget.attachments.isNotEmpty) ...[
-                    // The inset rides inside the strip's scroll view rather
-                    // than around it: at rest nothing moves, but once the
-                    // strip overflows the tiles scroll under the gutter and
-                    // the last one is cut at the card's edge — the cue that
-                    // there is more, with no counter to draw.
-                    FlowAttachmentGroup(
-                      attachments: widget.attachments,
+              child: Container(
+                decoration: BoxDecoration(
+                  // The composer is the design's raised card: it sits above the
+                  // page rather than tinting it, in both themes, under a
+                  // barely-there ambient lift. The drop wash blends into the
+                  // ground rather than layering over it, so the card stays the
+                  // one opaque surface even while lit.
+                  color: _dropHover
+                      ? Color.alphaBlend(
+                          highlight.withValues(alpha: _dropWashAlpha),
+                          ground,
+                        )
+                      : ground,
+                  borderRadius: radius,
+                  boxShadow: [
+                    BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
+                  ],
+                ),
+                padding: widget.padding ?? _cardPadding,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (widget.attachments.isNotEmpty) ...[
+                      // The inset rides inside the strip's scroll view rather
+                      // than around it: at rest nothing moves, but once the
+                      // strip overflows the tiles scroll under the gutter and
+                      // the last one is cut at the card's edge — the cue that
+                      // there is more, with no counter to draw.
+                      FlowAttachmentGroup(
+                        attachments: widget.attachments,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: _contentInset,
+                        ),
+                        onTap: widget.onAttachmentTap,
+                        // Editing is what `enabled` gates; viewing an attachment
+                        // that is already pending stays available, as does the
+                        // send button while streaming.
+                        onRemove: widget.enabled
+                            ? widget.onRemoveAttachment
+                            : null,
+                        removeTooltip: widget.removeAttachmentTooltip,
+                        previewCloseTooltip: widget.previewCloseTooltip,
+                      ),
+                      const SizedBox(height: _attachmentGap),
+                    ],
+                    Padding(
                       padding: const EdgeInsets.symmetric(
                         horizontal: _contentInset,
                       ),
-                      onTap: widget.onAttachmentTap,
-                      // Editing is what `enabled` gates; viewing an attachment
-                      // that is already pending stays available, as does the
-                      // send button while streaming.
-                      onRemove: widget.enabled
-                          ? widget.onRemoveAttachment
-                          : null,
-                      removeTooltip: widget.removeAttachmentTooltip,
-                      previewCloseTooltip: widget.previewCloseTooltip,
-                    ),
-                    const SizedBox(height: _attachmentGap),
-                  ],
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: _contentInset,
-                    ),
-                    child: Container(
-                      constraints: const BoxConstraints(
-                        minHeight: _fieldMinHeight,
-                      ),
-                      alignment: AlignmentDirectional.topStart,
-                      child: Focus(
-                        onKeyEvent: _handleKeyEvent,
-                        child: TextField(
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          enabled: widget.enabled,
-                          minLines: 1,
-                          maxLines: widget.maxLines,
-                          // The design's compressed composer: body face on
-                          // the 1.3 control line, so the empty card stands
-                          // at 116.
-                          style: typography.bodyLarge
-                              .copyWith(height: 1.3, color: colors.onSurface)
-                              .merge(style?.textStyle),
-                          // Android's IME rich-content path, the one media
-                          // input the SDK covers without a plugin.
-                          contentInsertionConfiguration:
-                              widget.onContentInserted == null ||
-                                  !widget.attachmentsEnabled
-                              ? null
-                              : ContentInsertionConfiguration(
-                                  onContentInserted: widget.onContentInserted!,
-                                ),
-                          decoration: InputDecoration(
-                            isDense: true,
-                            border: InputBorder.none,
-                            hintText: widget.placeholder,
-                            hintStyle: typography.bodyLarge.copyWith(
-                              height: 1.3,
-                              color: style?.hintColor ?? colors.onSurfaceMuted,
+                      child: Container(
+                        constraints: const BoxConstraints(
+                          minHeight: _fieldMinHeight,
+                        ),
+                        alignment: AlignmentDirectional.topStart,
+                        child: Focus(
+                          onKeyEvent: _handleKeyEvent,
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            groupId: _tapGroup,
+                            enabled: widget.enabled,
+                            minLines: 1,
+                            maxLines: widget.maxLines,
+                            // The design's compressed composer: body face on
+                            // the 1.3 control line, so the empty card stands
+                            // at 116.
+                            style: typography.bodyLarge
+                                .copyWith(height: 1.3, color: colors.onSurface)
+                                .merge(style?.textStyle),
+                            // Android's IME rich-content path, the one media
+                            // input the SDK covers without a plugin.
+                            contentInsertionConfiguration:
+                                widget.onContentInserted == null ||
+                                    !widget.attachmentsEnabled
+                                ? null
+                                : ContentInsertionConfiguration(
+                                    onContentInserted:
+                                        widget.onContentInserted!,
+                                  ),
+                            decoration: InputDecoration(
+                              isDense: true,
+                              border: InputBorder.none,
+                              hintText: widget.placeholder,
+                              hintStyle: typography.bodyLarge.copyWith(
+                                height: 1.3,
+                                color:
+                                    style?.hintColor ?? colors.onSurfaceMuted,
+                              ),
+                              contentPadding: EdgeInsets.zero,
                             ),
-                            contentPadding: EdgeInsets.zero,
                           ),
                         ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: _fieldGap),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: _actionInset,
+                    const SizedBox(height: _fieldGap),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: _actionInset,
+                      ),
+                      child: Row(
+                        children: [
+                          // The built-in attach affordance leads the row; being
+                          // outside the loop keeps the pill-pair gap logic
+                          // reading only the host's actions.
+                          if (widget.attachmentsEnabled &&
+                              (widget.onAttach != null ||
+                                  widget.onAttachmentsPicked != null)) ...[
+                            _buildAttachButton(context),
+                            const SizedBox(width: _leadingGap),
+                          ],
+                          for (
+                            var i = 0;
+                            i < widget.leadingActions.length;
+                            i++
+                          ) ...[
+                            widget.leadingActions[i],
+                            // Two neighbouring pills read as a set and take the
+                            // design's wider step — 8, closing to 6 on phones —
+                            // while everything else keeps the action row's 4.
+                            SizedBox(
+                              width:
+                                  i + 1 < widget.leadingActions.length &&
+                                      widget.leadingActions[i] is FlowPill &&
+                                      widget.leadingActions[i + 1] is FlowPill
+                                  ? (_isMobile(context)
+                                        ? _mobilePillGap
+                                        : _pillGap)
+                                  : _leadingGap,
+                            ),
+                          ],
+                          const Spacer(),
+                          for (final action in widget.trailingActions) ...[
+                            action,
+                            const SizedBox(width: _trailingGap),
+                          ],
+                          _buildSendStopButton(context),
+                        ],
+                      ),
                     ),
-                    child: Row(
-                      children: [
-                        // The built-in attach affordance leads the row; being
-                        // outside the loop keeps the pill-pair gap logic
-                        // reading only the host's actions.
-                        if (widget.attachmentsEnabled &&
-                            (widget.onAttach != null ||
-                                widget.onAttachmentsPicked != null)) ...[
-                          _buildAttachButton(context),
-                          const SizedBox(width: _leadingGap),
-                        ],
-                        for (
-                          var i = 0;
-                          i < widget.leadingActions.length;
-                          i++
-                        ) ...[
-                          widget.leadingActions[i],
-                          // Two neighbouring pills read as a set and take the
-                          // design's wider step — 8, closing to 6 on phones —
-                          // while everything else keeps the action row's 4.
-                          SizedBox(
-                            width:
-                                i + 1 < widget.leadingActions.length &&
-                                    widget.leadingActions[i] is FlowPill &&
-                                    widget.leadingActions[i + 1] is FlowPill
-                                ? (_isMobile(context)
-                                      ? _mobilePillGap
-                                      : _pillGap)
-                                : _leadingGap,
-                          ),
-                        ],
-                        const Spacer(),
-                        for (final action in widget.trailingActions) ...[
-                          action,
-                          const SizedBox(width: _trailingGap),
-                        ],
-                        _buildSendStopButton(context),
-                      ],
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary

Makes the whole composer card the field's click target.

- A click on the card's padding, the gap under the field, or the empty stretch of the action row now focuses the field. Before, only the field's own text run took the click, so a card with a short draft was mostly dead space.
- The pointer shows the text cursor over the card while it is enabled, `basic` when disabled.
- Implemented as a `GestureDetector` (`HitTestBehavior.opaque`) around the card and a `cursor` on the existing hover `MouseRegion`. The attach button, send/stop disc, attachment tiles, host actions and the `TextField` sit deeper in the tree, so they keep their own taps and cursors.
- Changelog entry and one sentence in the composer docs.

## Screenshots

Interaction only. The card's rest and active states are unchanged, so a static frame shows nothing new.

## How this was verified

- Example app on Chrome, hot reloaded: clicking the card's padding, the gap under the field and the empty part of the action row focuses the field; the `+` button, the model selector and the send disc still take their own clicks; the I-beam shows over the card and the click cursor over its controls.
- `flutter analyze` clean at the root and in `example/` and `playground/`; `dart format .` applied.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [ ] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized interaction change in `FlowComposer` with documented tap-region handling; no auth, data, or public API surface changes.
> 
> **Overview**
> **Fixes composer UX** so the raised input card behaves like a single text field: padding, the gap under the draft, and empty space in the action row now focus the `TextField` and show the I-beam when enabled.
> 
> Implementation wraps the card in a `MouseRegion` (text vs basic cursor), `TextFieldTapRegion` (avoids blur-on-down / refocus-on-up and keeps selection toolbar in the default tap group), and an opaque `GestureDetector` that calls `requestFocus`. Child controls—attach, send/stop, attachment tiles, and host actions—stay on top in the hit test so their taps and cursors are unchanged.
> 
> Changelog and composer docs note the new click target; no API or visual state changes beyond pointer/focus behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7f47696d784fa04c965f3dd1700bf2b5251d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->