### PR TITLE
docs: mirror each page's og title and description into twitter tags

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,8 @@ export default defineConfig({
 				},
 			],
 			components: {
+				// Mirrors each page's og:title/description into the twitter: pair.
+				Head: './src/components/Head.astro',
 				PageTitle: './src/components/PageTitle.astro',
 				ThemeSelect: './src/components/ThemeSelect.astro',
 				SiteTitle: './src/components/SiteTitle.astro',

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,20 @@
+---
+/**
+ * Overrides Starlight's Head: emits every tag Starlight computed for the
+ * page, then mirrors its `og:title` and `og:description` into the
+ * `twitter:` pair. X reads the `og:` tags when these are absent, so the
+ * card renders the same either way; this only keeps card validators
+ * quiet. Done here rather than in astro.config's `head` because that is
+ * one static tag for every page, and X prefers `twitter:title` over
+ * `og:title` — a static one would give every subpage the home title.
+ */
+const { head } = Astro.locals.starlightRoute;
+const meta = (property: string) =>
+	head.find((tag) => tag.tag === 'meta' && tag.attrs?.property === property)?.attrs?.content;
+const title = meta('og:title');
+const description = meta('og:description');
+---
+
+{head.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
+{title && <meta name="twitter:title" content={title} />}
+{description && <meta name="twitter:description" content={description} />}


### PR DESCRIPTION
## Summary

Adds `twitter:title` and `twitter:description` to every docs page, mirroring the page's own `og:title` and `og:description`.

- Card validators flag the two as missing. X falls back to the `og:` pair, so the rendered card does not change; this only makes the report clean.
- Done as a Starlight `Head` override rather than in `astro.config`'s `head:`. That config is one static tag for every page, and X prefers `twitter:title` over `og:title`, so a static one would give every subpage the home title.
- The override reads the `og:` values from the head Starlight already computed, so the two pairs cannot drift, including on the home page where Starlight strips the site name.

## How this was verified

- `npm run build` in `docs/`: 22 pages, no warnings.
- Inspected `dist/index.html` and `dist/components/composer/index.html`: each carries `twitter:title` and `twitter:description` equal to its own `og:` pair (launch title on the home page, "Message composer" on the subpage).

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only HTML meta tags; no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Starlight `Head` override** so every docs page emits **`twitter:title`** and **`twitter:description`** copied from that page’s existing **`og:title`** and **`og:description`**.
> 
> `astro.config.mjs` registers the custom `Head` component instead of relying on static `head` entries, which would apply one title site-wide and break subpages (X prefers `twitter:title` over `og:title`). Behavior for shared cards is unchanged—validators get the missing tags without duplicating metadata logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7501ee7bd0cec4f6c00d56f0eb739e2fa5767f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->