### PR TITLE
fix: settle a thread stranded outside its scroll range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,16 @@
   body and the inline span, drop from 14 to 13 on their 1.6 and 1.5
   lines.
 
+- **Fix** — the thread no longer strands at a scroll offset outside its
+  range: the newest message clipped under the list's bottom edge with
+  blank space beneath, or a blank band above the oldest. Flutter keeps an
+  offset that has left the range — a drag that dismisses the keyboard
+  grows the viewport mid-gesture while a reply is still growing — and
+  only the next gesture pulled it back. `FlowThread` now clamps an idle
+  position back into range, on every metrics change and scroll end, and
+  creates its own controller when the host passes none.
+
+
 ## 0.2.0
 
 - **Typography** — title and label roles now carry an emphasised cut

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:material_ui/material_ui.dart';
 
@@ -158,6 +159,15 @@ class _FlowThreadState extends State<FlowThread> {
   bool _fits = false;
   Timer? _fitsHold;
 
+  /// The list's controller when the host passes none: the settle below
+  /// needs a position to correct, and the notification alone offers none.
+  ScrollController? _internalController;
+  ScrollController get _controller =>
+      widget.controller ?? (_internalController ??= ScrollController());
+
+  /// Whether a settle is already queued for the frame's end.
+  bool _settling = false;
+
   /// Whether any message is mid-turn, read each build. The fit flip is
   /// frozen while streaming: swapping the list's viewport type remounts
   /// the whole subtree, resetting every reveal — mid-stream that reset
@@ -174,10 +184,63 @@ class _FlowThreadState extends State<FlowThread> {
   @override
   void dispose() {
     _fitsHold?.cancel();
+    _internalController?.dispose();
     super.dispose();
   }
 
+  /// How far outside its range an idle position may sit before it is
+  /// pulled back: sub-pixel drift is not a stranded offset.
+  static const double _settleTolerance = 0.5;
+
+  static bool _inRange(ScrollMetrics metrics) =>
+      metrics.pixels >= metrics.minScrollExtent - _settleTolerance &&
+      metrics.pixels <= metrics.maxScrollExtent + _settleTolerance;
+
+  /// An idle position must sit inside its range. Flutter leaves one that
+  /// has already left it where it is: `RangeMaintainingScrollPhysics`
+  /// stops enforcing the boundary once a position is out of range and
+  /// carries the overshoot as the range shrinks, and only a gesture's
+  /// ballistic pulls it back. The keyboard is how it gets there — a drag
+  /// dismisses it (the default `keyboardDismissBehavior`), the viewport
+  /// grows mid-gesture while a reply is still growing, and the range
+  /// collapses under the offset. A reversed list stranded past its end
+  /// shows its content shifted down, the newest message clipped under the
+  /// list's own bottom edge and the jump button hidden below its
+  /// threshold: a thread cut off mid-screen with blank space beneath. Past
+  /// its start, a blank band above the oldest message instead. Clamping
+  /// back in is what the physics does at the end of every gesture, done
+  /// here for the idle case it skips.
+  ///
+  /// Runs on every metrics change and on every scroll end: the range
+  /// collapses mid-gesture, when a jump would fight the physics, and a
+  /// gesture merely ending changes no metrics — so each covers the other.
+  /// The correction goes through the controller, which needs a single
+  /// position; a host sharing one across lists opts out of the settle.
+  void _settleIfOff(ScrollMetrics metrics) {
+    if (_settling || _inRange(metrics)) return;
+    _settling = true;
+    // Metrics arrive during layout; the jump waits for the frame's end.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _settling = false;
+      if (!mounted) return;
+      final controller = _controller;
+      if (!controller.hasClients || controller.positions.length != 1) return;
+      final position = controller.position;
+      // Re-read live: the offset the notification reported may have moved
+      // on, and a gesture or its ballistic in progress settles on its own.
+      if (position.isScrollingNotifier.value || _inRange(position)) return;
+      controller.jumpTo(
+        clampDouble(
+          position.pixels,
+          position.minScrollExtent,
+          position.maxScrollExtent,
+        ),
+      );
+    });
+  }
+
   void _handleMetrics(ScrollMetrics metrics) {
+    _settleIfOff(metrics);
     final fits = metrics.maxScrollExtent <= 0;
     final first = _metricsFits == null;
     _metricsFits = fits;
@@ -255,57 +318,63 @@ class _FlowThreadState extends State<FlowThread> {
     final messages = widget.messages;
     _syncStreaming(messages);
 
-    return NotificationListener<ScrollMetricsNotification>(
+    return NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
-        // Depth 0 is the thread's own list — scrollers nested inside
-        // messages (attachment strips, code blocks) report deeper and
-        // must not steer the fit.
-        if (notification.depth == 0) _handleMetrics(notification.metrics);
+        if (notification.depth == 0) _settleIfOff(notification.metrics);
         return false;
       },
-      child: Align(
-        alignment: AlignmentDirectional.topCenter,
-        child: ListView.builder(
-          controller: widget.controller,
-          reverse: true,
-          shrinkWrap: _fits,
-          scrollCacheExtent: _cacheExtent,
-          keyboardDismissBehavior: widget.keyboardDismissBehavior,
-          padding: widget.padding ?? _defaultPadding,
-          itemCount: messages.length,
-          itemBuilder: (context, index) {
-            // Reversed list: index 0 is the newest (bottom) message.
-            final message = messages[messages.length - 1 - index];
-            final isOldest = index == messages.length - 1;
-            return Padding(
-              key: ValueKey(message.id),
-              padding: EdgeInsets.only(top: isOldest ? 0 : gap),
-              child:
-                  widget.messageBuilder?.call(context, message) ??
-                  FlowMessage(
-                    message,
-                    customPartBuilder: widget.customPartBuilder,
-                    onAttachmentTap: onAttachmentTap == null
-                        ? null
-                        : (attachmentId) =>
-                              onAttachmentTap(message, attachmentId),
-                    previewCloseTooltip: widget.previewCloseTooltip,
-                    onCodeCopy: widget.onCodeCopy,
-                    copiedCodePart: widget.copiedCodePart,
-                    codeCopyTooltip: widget.codeCopyTooltip,
-                    markdown: widget.markdown,
-                    onLinkTap: onLinkTap == null
-                        ? null
-                        : (href) => onLinkTap(message, href),
-                    onRetry: onRetry == null ? null : () => onRetry(message),
-                    errorTitle: widget.errorTitle,
-                    retryLabel: widget.retryLabel,
-                    charactersPerSecond: widget.charactersPerSecond,
-                    thinkingLabel: widget.thinkingLabel,
-                    footer: widget.messageFooter?.call(message),
-                  ),
-            );
-          },
+      child: NotificationListener<ScrollMetricsNotification>(
+        onNotification: (notification) {
+          // Depth 0 is the thread's own list — scrollers nested inside
+          // messages (attachment strips, code blocks) report deeper and
+          // must not steer the fit.
+          if (notification.depth == 0) _handleMetrics(notification.metrics);
+          return false;
+        },
+        child: Align(
+          alignment: AlignmentDirectional.topCenter,
+          child: ListView.builder(
+            controller: _controller,
+            reverse: true,
+            shrinkWrap: _fits,
+            scrollCacheExtent: _cacheExtent,
+            keyboardDismissBehavior: widget.keyboardDismissBehavior,
+            padding: widget.padding ?? _defaultPadding,
+            itemCount: messages.length,
+            itemBuilder: (context, index) {
+              // Reversed list: index 0 is the newest (bottom) message.
+              final message = messages[messages.length - 1 - index];
+              final isOldest = index == messages.length - 1;
+              return Padding(
+                key: ValueKey(message.id),
+                padding: EdgeInsets.only(top: isOldest ? 0 : gap),
+                child:
+                    widget.messageBuilder?.call(context, message) ??
+                    FlowMessage(
+                      message,
+                      customPartBuilder: widget.customPartBuilder,
+                      onAttachmentTap: onAttachmentTap == null
+                          ? null
+                          : (attachmentId) =>
+                                onAttachmentTap(message, attachmentId),
+                      previewCloseTooltip: widget.previewCloseTooltip,
+                      onCodeCopy: widget.onCodeCopy,
+                      copiedCodePart: widget.copiedCodePart,
+                      codeCopyTooltip: widget.codeCopyTooltip,
+                      markdown: widget.markdown,
+                      onLinkTap: onLinkTap == null
+                          ? null
+                          : (href) => onLinkTap(message, href),
+                      onRetry: onRetry == null ? null : () => onRetry(message),
+                      errorTitle: widget.errorTitle,
+                      retryLabel: widget.retryLabel,
+                      charactersPerSecond: widget.charactersPerSecond,
+                      thinkingLabel: widget.thinkingLabel,
+                      footer: widget.messageFooter?.call(message),
+                    ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -159,12 +159,6 @@ class _FlowThreadState extends State<FlowThread> {
   bool _fits = false;
   Timer? _fitsHold;
 
-  /// The list's controller when the host passes none: the settle below
-  /// needs a position to correct, and the notification alone offers none.
-  ScrollController? _internalController;
-  ScrollController get _controller =>
-      widget.controller ?? (_internalController ??= ScrollController());
-
   /// Whether a settle is already queued for the frame's end.
   bool _settling = false;
 
@@ -184,7 +178,6 @@ class _FlowThreadState extends State<FlowThread> {
   @override
   void dispose() {
     _fitsHold?.cancel();
-    _internalController?.dispose();
     super.dispose();
   }
 
@@ -214,22 +207,24 @@ class _FlowThreadState extends State<FlowThread> {
   /// Runs on every metrics change and on every scroll end: the range
   /// collapses mid-gesture, when a jump would fight the physics, and a
   /// gesture merely ending changes no metrics — so each covers the other.
-  /// The correction goes through the controller, which needs a single
-  /// position; a host sharing one across lists opts out of the settle.
-  void _settleIfOff(ScrollMetrics metrics) {
-    if (_settling || _inRange(metrics)) return;
+  /// The correction goes through the position that fired the
+  /// notification, found from its context, so the list needs no
+  /// controller of its own and keeps the primary one a host relies on for
+  /// the chat view's scrollbar and the status-bar tap.
+  void _settleIfOff(ScrollMetrics metrics, BuildContext? context) {
+    if (context == null || _settling || _inRange(metrics)) return;
+    final scrollable = context.findAncestorStateOfType<ScrollableState>();
+    if (scrollable == null) return;
     _settling = true;
     // Metrics arrive during layout; the jump waits for the frame's end.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _settling = false;
-      if (!mounted) return;
-      final controller = _controller;
-      if (!controller.hasClients || controller.positions.length != 1) return;
-      final position = controller.position;
+      if (!mounted || !scrollable.mounted) return;
+      final position = scrollable.position;
       // Re-read live: the offset the notification reported may have moved
       // on, and a gesture or its ballistic in progress settles on its own.
       if (position.isScrollingNotifier.value || _inRange(position)) return;
-      controller.jumpTo(
+      position.jumpTo(
         clampDouble(
           position.pixels,
           position.minScrollExtent,
@@ -239,8 +234,8 @@ class _FlowThreadState extends State<FlowThread> {
     });
   }
 
-  void _handleMetrics(ScrollMetrics metrics) {
-    _settleIfOff(metrics);
+  void _handleMetrics(ScrollMetrics metrics, BuildContext context) {
+    _settleIfOff(metrics, context);
     final fits = metrics.maxScrollExtent <= 0;
     final first = _metricsFits == null;
     _metricsFits = fits;
@@ -320,7 +315,9 @@ class _FlowThreadState extends State<FlowThread> {
 
     return NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
-        if (notification.depth == 0) _settleIfOff(notification.metrics);
+        if (notification.depth == 0) {
+          _settleIfOff(notification.metrics, notification.context);
+        }
         return false;
       },
       child: NotificationListener<ScrollMetricsNotification>(
@@ -328,13 +325,15 @@ class _FlowThreadState extends State<FlowThread> {
           // Depth 0 is the thread's own list — scrollers nested inside
           // messages (attachment strips, code blocks) report deeper and
           // must not steer the fit.
-          if (notification.depth == 0) _handleMetrics(notification.metrics);
+          if (notification.depth == 0) {
+            _handleMetrics(notification.metrics, notification.context);
+          }
           return false;
         },
         child: Align(
           alignment: AlignmentDirectional.topCenter,
           child: ListView.builder(
-            controller: _controller,
+            controller: widget.controller,
             reverse: true,
             shrinkWrap: _fits,
             scrollCacheExtent: _cacheExtent,


### PR DESCRIPTION
## Summary

Fixes the thread stranding at a scroll offset outside its range: the newest message clipped under the list's bottom edge with blank space beneath (a short, fitting thread), or a blank band above the oldest (a long one).

- Flutter keeps an offset that has already left the range. `RangeMaintainingScrollPhysics` stops enforcing the boundary once a position is out of range and carries the overshoot as the range shrinks; only the next gesture's ballistic pulls it back. The keyboard is the way in: a drag dismisses it (the default `keyboardDismissBehavior`), the viewport grows mid-gesture while a reply is still growing, and the range collapses under the offset.
- `FlowThread` now clamps an idle position back into range. It runs on every metrics change and on every scroll end, since the range collapses mid-gesture (when a jump would fight the physics) and a gesture merely ending changes no metrics. Each covers the other's blind spot.
- The list gets its own controller when the host passes none; the correction needs a position. A host sharing one controller across lists opts out of the settle.

## Screenshots

Interaction only; the fix removes a broken state rather than changing a drawn one. The original report's screenshot (reply cut mid-screen, blank below) is the before.

## How this was verified

- iPhone 17 Pro simulator, example app: send with the keyboard up, drag the thread to dismiss it while the reply streams; the reply stays pinned above the composer, and the settled thread reads from the top. Repeated with a long thread.
- `flutter analyze` clean at the root and in `example/` and `playground/`; `dart format .` applied.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized scroll-position correction in the thread widget; avoids fighting in-flight scroll physics with explicit guards.
> 
> **Overview**
> Fixes **`FlowThread`** leaving the conversation scrolled to an invalid offset after the viewport grows (e.g. keyboard dismissed on drag while a reply is still streaming), which could clip the newest message or show blank space above the oldest.
> 
> Adds **`_settleIfOff`**: when metrics show the list idle and outside range (with a small tolerance), it **`jumpTo`**-clamps pixels between min/max extent on the **post-frame** callback, skipping active gestures and duplicate work via **`_settling`**. Settlement runs from **`ScrollMetricsNotification`** (inside existing **`_handleMetrics`**) and a new outer **`ScrollEndNotification`** listener so mid-gesture range collapse and gesture-end cases are both covered. Position is resolved from the notification’s **`ScrollableState`**, so hosts can keep sharing an external **`ScrollController`**.
> 
> **`CHANGELOG.md`** documents the user-facing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee09358e5e79414282920ca57434a7a22704c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->