### PR TITLE
fix: phone touch targets, send and stop names, and the Flow caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,11 +206,12 @@
 
 - **Touch targets** — the message actions, the composer's attach glyph
   and error-dismiss cross, the menu triggers and the code block's copy
-  affordance take a finger's reach on phones: the actions strip the
-  row's pitch wide by 32 tall on its 20px frames, the attach and menu
-  triggers 40, the copy 36, the dismiss 30, each reserved in layout and
-  absorbed from the gap beside it, so the drawn frames stay where the
-  design put them. Pointer platforms are untouched.
+  affordance take a finger's reach on phones: the actions strip its
+  pitch wide and the footer gap taller on its 20px frames, the attach,
+  menu and send discs the row's 40 tall, the copy 36, the dismiss 30,
+  each reserved in layout and absorbed from the gap beside it, so the
+  drawn frames stay where the design put them. Pointer platforms are
+  untouched.
 - **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
   name the discs for assistive tech; before, both announced as unnamed
   buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,19 @@
   position back into range, on every metrics change and scroll end, and
   creates its own controller when the host passes none.
 
+- **Touch targets** — the message actions, the composer's attach and
+  stop discs, the attachment tile's cross, the error tab's cross, the
+  menu triggers and the code block's copy affordance now accept a finger
+  from a 44px reach on phones, sized per site so a neighbour's taps stay
+  its own, with the drawn frames unchanged. Pointer platforms are
+  untouched.
+- **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
+  name the discs for assistive tech; before, both announced as unnamed
+  buttons.
+- **Fix** — the caret, selection wash and handles across the chat view
+  and the composer take the Flow primary rather than the host
+  `ColorScheme`'s, which on a stock `ThemeData` was Material's purple.
+
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,12 +204,13 @@
   position back into range, on every metrics change and scroll end, and
   creates its own controller when the host passes none.
 
-- **Touch targets** — the message actions, the composer's attach and
-  stop discs, the attachment tile's cross, the error tab's cross, the
-  menu triggers and the code block's copy affordance now accept a finger
-  from a 44px reach on phones, sized per site so a neighbour's taps stay
-  its own, with the drawn frames unchanged. Pointer platforms are
-  untouched.
+- **Touch targets** — the message actions, the composer's attach glyph
+  and error-dismiss cross, the menu triggers and the code block's copy
+  affordance take a finger's reach on phones: the actions strip the
+  row's pitch wide by 32 tall on its 20px frames, the attach and menu
+  triggers 40, the copy 36, the dismiss 30, each reserved in layout and
+  absorbed from the gap beside it, so the drawn frames stay where the
+  design put them. Pointer platforms are untouched.
 - **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
   name the discs for assistive tech; before, both announced as unnamed
   buttons.

--- a/docs/src/content/docs/components/composer.mdx
+++ b/docs/src/content/docs/components/composer.mdx
@@ -369,6 +369,9 @@ wins field by field.
   `errorMessage` + `errorIcon` — the error banner above the card;
   `onErrorDismiss` + `errorDismissTooltip` draw its cross.
   `onContentInserted` — Android keyboard media insertion.
+- `sendTooltip`, `stopTooltip` — host-localized names for the send and
+  stop discs, and their accessible names; without them assistive tech
+  announces an unnamed button.
 - `controller`, `focusNode`, `placeholder` — the field itself; pass your
   own `TextEditingController` to prefill or clear the draft.
   `placeholder` defaults to 'How can I help you today?' — the one string

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flow_ui/flow_ui.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -462,7 +463,9 @@ class _ChatScreenState extends State<ChatScreen> {
         // Drag-and-drop, handled by the package. Web only — the SDK
         // implements OS file drop nowhere else — and a no-op elsewhere,
         // which is why the attach button carries the same job.
-        onAttachmentsDropped: _addAttachments,
+        // Web only: the SDK implements OS file drop nowhere else, and the
+        // package says so at runtime when handed the callback elsewhere.
+        onAttachmentsDropped: kIsWeb ? _addAttachments : null,
         onAttachmentRejected: _rejectAttachment,
         attachmentOptions: _attachmentOptions,
         dropLabel: 'Drop files to add to chat',
@@ -496,9 +499,11 @@ class _ChatScreenState extends State<ChatScreen> {
           isStreaming: _generating,
           onSend: _send,
           onStop: _stop,
+          sendTooltip: 'Send',
+          stopTooltip: 'Stop',
           // Picking goes through the "+" menu below; paste and drop land
           // in the same place — three ways in, one handler.
-          onAttachmentsPasted: _addAttachments,
+          onAttachmentsPasted: kIsWeb ? _addAttachments : null,
           onAttachmentRejected: _rejectAttachment,
           attachmentOptions: _attachmentOptions,
           // The design's error banner above the card; the words are this

--- a/lib/src/utils/flow_circle_button.dart
+++ b/lib/src/utils/flow_circle_button.dart
@@ -1,5 +1,7 @@
 import 'package:material_ui/material_ui.dart';
 
+import 'flow_touch_target.dart';
+
 // Internal chrome shared by the composer, the attachment tiles and the
 // attachment preview. Not exported from the package barrel.
 
@@ -75,6 +77,6 @@ class FlowCircleButton extends StatelessWidget {
     if (message != null) {
       button = Tooltip(message: message, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 }

--- a/lib/src/utils/flow_circle_button.dart
+++ b/lib/src/utils/flow_circle_button.dart
@@ -26,6 +26,7 @@ class FlowCircleButton extends StatelessWidget {
     this.iconSize = 18,
     this.padding,
     this.hoverColor,
+    this.touchMinSize = 0,
   });
 
   final IconData icon;
@@ -52,6 +53,10 @@ class FlowCircleButton extends StatelessWidget {
   /// [background] — the right behaviour when the disc is translucent.
   final Color? hoverColor;
 
+  /// A finger's reach on touch platforms, reserved square in layout; zero
+  /// leaves the disc its drawn size. Sites pass what they can hold.
+  final double touchMinSize;
+
   @override
   Widget build(BuildContext context) {
     Widget button = Material(
@@ -77,6 +82,11 @@ class FlowCircleButton extends StatelessWidget {
     if (message != null) {
       button = Tooltip(message: message, child: button);
     }
-    return FlowTouchTarget(child: button);
+    if (touchMinSize <= 0) return button;
+    return FlowTouchTarget(
+      minWidth: touchMinSize,
+      minHeight: touchMinSize,
+      child: button,
+    );
   }
 }

--- a/lib/src/utils/flow_selection_theme.dart
+++ b/lib/src/utils/flow_selection_theme.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart' show CupertinoTheme;
+import 'package:material_ui/material_ui.dart';
+
+import '../theme/flow_theme.dart';
+
+/// Text editing and selection in the Flow accent: the caret, the selection
+/// wash and the handles, plus the Cupertino primary that iOS draws its
+/// handles and toolbar with. Without this a host that installs [FlowTheme]
+/// on a stock `ThemeData` gets Material's default purple caret against
+/// Flow's primary — the one place the accent otherwise leaks through from
+/// the host's `ColorScheme`.
+class FlowSelectionTheme extends StatelessWidget {
+  const FlowSelectionTheme({super.key, required this.child});
+
+  final Widget child;
+
+  /// The selection wash: the accent at Material's own 40%.
+  static const double _selectionAlpha = 0.4;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = context.flowColors.primary;
+    return TextSelectionTheme(
+      data: TextSelectionThemeData(
+        cursorColor: primary,
+        selectionColor: primary.withValues(alpha: _selectionAlpha),
+        selectionHandleColor: primary,
+      ),
+      child: CupertinoTheme(
+        data: CupertinoTheme.of(context).copyWith(primaryColor: primary),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -25,6 +25,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     this.minWidth = 44,
     this.minHeight = 44,
     this.topShare = 0.5,
+    this.leftShare = 0.5,
     required Widget super.child,
   });
 
@@ -33,6 +34,11 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
 
   /// How much of the spare height sits above the child, 0–1.
   final double topShare;
+
+  /// How much of the spare width sits left of the child, 0–1: a strip's
+  /// first button keeps its frame at the strip's start, its last at the
+  /// end.
+  final double leftShare;
 
   /// Whether the theme's platform is one driven by touch.
   static bool isTouch(BuildContext context) {
@@ -47,6 +53,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
       minWidth: touch ? minWidth : 0,
       minHeight: touch ? minHeight : 0,
       topShare: topShare,
+      leftShare: leftShare,
     );
   }
 
@@ -59,7 +66,8 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     renderObject
       ..minWidth = touch ? minWidth : 0
       ..minHeight = touch ? minHeight : 0
-      ..topShare = topShare;
+      ..topShare = topShare
+      ..leftShare = leftShare;
   }
 }
 
@@ -70,6 +78,7 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     required this._minWidth,
     required this._minHeight,
     required this._topShare,
+    required this._leftShare,
     RenderBox? child,
   }) : super(child);
 
@@ -91,6 +100,13 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
   set topShare(double value) {
     if (value == _topShare) return;
     _topShare = value;
+    markNeedsLayout();
+  }
+
+  double _leftShare;
+  set leftShare(double value) {
+    if (value == _leftShare) return;
+    _leftShare = value;
     markNeedsLayout();
   }
 
@@ -130,7 +146,7 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     child.layout(constraints, parentUsesSize: true);
     size = constraints.constrain(_reserve(child.size));
     (child.parentData! as BoxParentData).offset = Offset(
-      (size.width - child.size.width) / 2,
+      (size.width - child.size.width) * _leftShare,
       (size.height - child.size.height) * _topShare,
     );
   }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -1,20 +1,21 @@
-import 'package:flutter/rendering.dart'
-    show BoxHitTestEntry, BoxHitTestResult, RenderProxyBox;
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// Widens a small control's hit area on touch platforms without changing
-/// its layout. The design draws message actions on a 20px frame and the
-/// composer's glyph buttons on 24–32px discs; a finger needs 44 (Apple) to
-/// 48 (Material) and neither guideline is met by the frame alone. Material
-/// reserves that space in layout, which would open the rows up; this keeps
-/// the drawn size and accepts hits from the surrounding [minWidth] by
-/// [minHeight], [topShare] of the vertical extension above the child and
-/// the rest below.
+/// Reserves a finger's reach around a small control on touch platforms.
+/// The design draws message actions on a 20px frame and the composer's
+/// glyph buttons on 24–32px discs; a finger needs 44 (Apple) to 48
+/// (Material). Every ancestor rejects a pointer outside its own box before
+/// its children are asked, so the reach has to exist in layout: this lays
+/// out at least [minWidth] by [minHeight], seats the child with [topShare]
+/// of the spare height above it, and routes a hit anywhere in the box to
+/// the child's nearest edge — Material's own tap-target padding.
 ///
-/// Sized per site rather than a flat 44: a hit area that reaches into a
-/// neighbouring control steals its taps, since siblings are hit-tested in
-/// reverse order rather than by distance. A row of 20px actions on a 4px
-/// pitch keeps [minWidth] at 24 and takes its reach vertically.
+/// Sized per site rather than a flat 44, and absorbed from the gap beside
+/// the control where one exists — the message strip grows up into the
+/// footer gap, the composer's attach into the row inset — so the drawn
+/// frames stay where the design put them.
 ///
 /// A pointer platform passes straight through, by the theme's platform as
 /// the menus and the composer resolve it, so hosts and tests can steer it.
@@ -30,17 +31,18 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
   final double minWidth;
   final double minHeight;
 
-  /// How much of the vertical extension sits above the child, 0–1.
+  /// How much of the spare height sits above the child, 0–1.
   final double topShare;
 
-  static bool _touch(BuildContext context) {
+  /// Whether the theme's platform is one driven by touch.
+  static bool isTouch(BuildContext context) {
     final platform = Theme.of(context).platform;
     return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
   }
 
   @override
   RenderFlowTouchTarget createRenderObject(BuildContext context) {
-    final touch = _touch(context);
+    final touch = isTouch(context);
     return RenderFlowTouchTarget(
       minWidth: touch ? minWidth : 0,
       minHeight: touch ? minHeight : 0,
@@ -53,7 +55,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     BuildContext context,
     RenderFlowTouchTarget renderObject,
   ) {
-    final touch = _touch(context);
+    final touch = isTouch(context);
     renderObject
       ..minWidth = touch ? minWidth : 0
       ..minHeight = touch ? minHeight : 0
@@ -61,41 +63,95 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
   }
 }
 
-/// The render side of [FlowTouchTarget]: lays out as its child and accepts
-/// hits from the wider reach.
-class RenderFlowTouchTarget extends RenderProxyBox {
+/// The render side of [FlowTouchTarget]: the child's size grown to the
+/// minimums, the child seated inside, every hit in the box the child's.
+class RenderFlowTouchTarget extends RenderShiftedBox {
   RenderFlowTouchTarget({
-    required this.minWidth,
-    required this.minHeight,
-    required this.topShare,
-  });
+    required this._minWidth,
+    required this._minHeight,
+    required this._topShare,
+    RenderBox? child,
+  }) : super(child);
 
-  double minWidth;
-  double minHeight;
-  double topShare;
+  double _minWidth;
+  set minWidth(double value) {
+    if (value == _minWidth) return;
+    _minWidth = value;
+    markNeedsLayout();
+  }
+
+  double _minHeight;
+  set minHeight(double value) {
+    if (value == _minHeight) return;
+    _minHeight = value;
+    markNeedsLayout();
+  }
+
+  double _topShare;
+  set topShare(double value) {
+    if (value == _topShare) return;
+    _topShare = value;
+    markNeedsLayout();
+  }
+
+  Size _reserve(Size childSize) => Size(
+    math.max(childSize.width, _minWidth),
+    math.max(childSize.height, _minHeight),
+  );
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      math.max(child?.getMinIntrinsicWidth(height) ?? 0, _minWidth);
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      math.max(child?.getMaxIntrinsicWidth(height) ?? 0, _minWidth);
+
+  @override
+  double computeMinIntrinsicHeight(double width) =>
+      math.max(child?.getMinIntrinsicHeight(width) ?? 0, _minHeight);
+
+  @override
+  double computeMaxIntrinsicHeight(double width) =>
+      math.max(child?.getMaxIntrinsicHeight(width) ?? 0, _minHeight);
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.constrain(
+    _reserve(child?.getDryLayout(constraints) ?? Size.zero),
+  );
+
+  @override
+  void performLayout() {
+    final child = this.child;
+    if (child == null) {
+      size = constraints.constrain(_reserve(Size.zero));
+      return;
+    }
+    child.layout(constraints, parentUsesSize: true);
+    size = constraints.constrain(_reserve(child.size));
+    (child.parentData! as BoxParentData).offset = Offset(
+      (size.width - child.size.width) / 2,
+      (size.height - child.size.height) * _topShare,
+    );
+  }
 
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    if (child == null) return false;
-    final extraX = (minWidth - size.width).clamp(0.0, double.infinity);
-    final extraY = (minHeight - size.height).clamp(0.0, double.infinity);
-    final reach = Rect.fromLTRB(
-      -extraX / 2,
-      -extraY * topShare,
-      size.width + extraX / 2,
-      size.height + extraY * (1 - topShare),
+    if (super.hitTest(result, position: position)) return true;
+    final child = this.child;
+    if (child == null || !size.contains(position)) return false;
+    // In the reach but off the child: the hit lands on the child's
+    // nearest edge, so its gesture and ink both accept it.
+    final offset = (child.parentData! as BoxParentData).offset;
+    final local = position - offset;
+    final nearest = Offset(
+      local.dx.clamp(0.0, child.size.width - 0.01),
+      local.dy.clamp(0.0, child.size.height - 0.01),
     );
-    if (!reach.contains(position)) return false;
-    // A hit outside the child's own bounds lands on its nearest edge, so
-    // the control's gesture and ink both accept it.
-    final inside = Offset(
-      position.dx.clamp(0.0, size.width - 0.01),
-      position.dy.clamp(0.0, size.height - 0.01),
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(nearest),
+      position: nearest,
+      hitTest: (result, position) => child.hitTest(result, position: nearest),
     );
-    if (hitTestChildren(result, position: inside)) {
-      result.add(BoxHitTestEntry(this, position));
-      return true;
-    }
-    return false;
   }
 }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -10,7 +10,7 @@ import 'package:material_ui/material_ui.dart';
 /// its children are asked, so the reach has to exist in layout: this lays
 /// out at least [minWidth] by [minHeight], seats the child with [topShare]
 /// of the spare height above it, and routes a hit anywhere in the box to
-/// the child's nearest edge — Material's own tap-target padding.
+/// the child's centre — Material's own tap-target padding.
 ///
 /// Sized per site rather than a flat 44, and absorbed from the gap beside
 /// the control where one exists — the message strip grows up into the
@@ -156,18 +156,14 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     if (super.hitTest(result, position: position)) return true;
     final child = this.child;
     if (child == null || !size.contains(position)) return false;
-    // In the reach but off the child: the hit lands on the child's
-    // nearest edge, so its gesture and ink both accept it.
-    final offset = (child.parentData! as BoxParentData).offset;
-    final local = position - offset;
-    final nearest = Offset(
-      local.dx.clamp(0.0, child.size.width - 0.01),
-      local.dy.clamp(0.0, child.size.height - 0.01),
-    );
+    // In the reach but off the control: the hit lands on the child's
+    // centre, Material's own rule, so the control's gesture and ink take
+    // it whatever frame or ring sits around them.
+    final center = child.size.center(Offset.zero);
     return result.addWithRawTransform(
-      transform: MatrixUtils.forceToPoint(nearest),
-      position: nearest,
-      hitTest: (result, position) => child.hitTest(result, position: nearest),
+      transform: MatrixUtils.forceToPoint(center),
+      position: center,
+      hitTest: (result, position) => child.hitTest(result, position: center),
     );
   }
 }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/rendering.dart'
+    show BoxHitTestEntry, BoxHitTestResult, RenderProxyBox;
+import 'package:material_ui/material_ui.dart';
+
+/// Widens a small control's hit area on touch platforms without changing
+/// its layout. The design draws message actions on a 20px frame and the
+/// composer's glyph buttons on 24–32px discs; a finger needs 44 (Apple) to
+/// 48 (Material) and neither guideline is met by the frame alone. Material
+/// reserves that space in layout, which would open the rows up; this keeps
+/// the drawn size and accepts hits from the surrounding [minWidth] by
+/// [minHeight], [topShare] of the vertical extension above the child and
+/// the rest below.
+///
+/// Sized per site rather than a flat 44: a hit area that reaches into a
+/// neighbouring control steals its taps, since siblings are hit-tested in
+/// reverse order rather than by distance. A row of 20px actions on a 4px
+/// pitch keeps [minWidth] at 24 and takes its reach vertically.
+///
+/// A pointer platform passes straight through, by the theme's platform as
+/// the menus and the composer resolve it, so hosts and tests can steer it.
+class FlowTouchTarget extends SingleChildRenderObjectWidget {
+  const FlowTouchTarget({
+    super.key,
+    this.minWidth = 44,
+    this.minHeight = 44,
+    this.topShare = 0.5,
+    required Widget super.child,
+  });
+
+  final double minWidth;
+  final double minHeight;
+
+  /// How much of the vertical extension sits above the child, 0–1.
+  final double topShare;
+
+  static bool _touch(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
+  }
+
+  @override
+  RenderFlowTouchTarget createRenderObject(BuildContext context) {
+    final touch = _touch(context);
+    return RenderFlowTouchTarget(
+      minWidth: touch ? minWidth : 0,
+      minHeight: touch ? minHeight : 0,
+      topShare: topShare,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderFlowTouchTarget renderObject,
+  ) {
+    final touch = _touch(context);
+    renderObject
+      ..minWidth = touch ? minWidth : 0
+      ..minHeight = touch ? minHeight : 0
+      ..topShare = topShare;
+  }
+}
+
+/// The render side of [FlowTouchTarget]: lays out as its child and accepts
+/// hits from the wider reach.
+class RenderFlowTouchTarget extends RenderProxyBox {
+  RenderFlowTouchTarget({
+    required this.minWidth,
+    required this.minHeight,
+    required this.topShare,
+  });
+
+  double minWidth;
+  double minHeight;
+  double topShare;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (child == null) return false;
+    final extraX = (minWidth - size.width).clamp(0.0, double.infinity);
+    final extraY = (minHeight - size.height).clamp(0.0, double.infinity);
+    final reach = Rect.fromLTRB(
+      -extraX / 2,
+      -extraY * topShare,
+      size.width + extraX / 2,
+      size.height + extraY * (1 - topShare),
+    );
+    if (!reach.contains(position)) return false;
+    // A hit outside the child's own bounds lands on its nearest edge, so
+    // the control's gesture and ink both accept it.
+    final inside = Offset(
+      position.dx.clamp(0.0, size.width - 0.01),
+      position.dy.clamp(0.0, size.height - 0.01),
+    );
+    if (hitTestChildren(result, position: inside)) {
+      result.add(BoxHitTestEntry(this, position));
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/src/widgets/flow_chat_view.dart
+++ b/lib/src/widgets/flow_chat_view.dart
@@ -9,6 +9,7 @@ import '../models/flow_attachment_options.dart';
 import '../styles/flow_chat_view_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
 import 'flow_drop_target.dart';
 import 'flow_thread.dart';
 
@@ -371,13 +372,17 @@ class _FlowChatViewState extends State<FlowChatView> {
     // Outside the SafeArea, so the drop rectangle is the whole surface —
     // the treatment is full-bleed and the target should match it. A plain
     // pass-through off the web, where it registers nothing.
-    return FlowDropTarget(
-      onDropped: widget.onAttachmentsDropped,
-      enabled: widget.attachmentsEnabled,
-      onHoverChanged: _handleDropHover,
-      attachmentOptions: widget.attachmentOptions,
-      onAttachmentRejected: widget.onAttachmentRejected,
-      child: _buildSurface(context, safeBottom),
+    // Editing and selection in the Flow accent for everything on the
+    // surface — the composer's caret, a selected code block's wash.
+    return FlowSelectionTheme(
+      child: FlowDropTarget(
+        onDropped: widget.onAttachmentsDropped,
+        enabled: widget.attachmentsEnabled,
+        onHoverChanged: _handleDropHover,
+        attachmentOptions: widget.attachmentOptions,
+        onAttachmentRejected: widget.onAttachmentRejected,
+        child: _buildSurface(context, safeBottom),
+      ),
     );
   }
 

--- a/lib/src/widgets/flow_code_block.dart
+++ b/lib/src/widgets/flow_code_block.dart
@@ -4,6 +4,7 @@ import '../styles/flow_code_block_style.dart';
 import '../theme/flow_syntax_colors.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_syntax_highlighter.dart';
+import '../utils/flow_touch_target.dart';
 
 export '../utils/flow_syntax_highlighter.dart'
     show FlowCodeLanguage, FlowSyntaxRule, FlowSyntaxToken;
@@ -383,6 +384,6 @@ class _CopyButtonState extends State<_CopyButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 }

--- a/lib/src/widgets/flow_code_block.dart
+++ b/lib/src/widgets/flow_code_block.dart
@@ -107,6 +107,16 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
     vertical: 12,
   );
   static const double _headerHeight = 36;
+
+  /// On touch platforms the copy affordance takes the header's height as
+  /// its reach, 6 a side in width; the header's inset gives up those 6 so
+  /// the glyph draws where it did, and the label keeps its 10 from the top
+  /// on its own.
+  static const EdgeInsetsGeometry _headerPaddingTouch = EdgeInsets.only(
+    left: 16,
+    right: 6,
+  );
+  static const double _labelTop = 10;
   static const EdgeInsetsGeometry _headerPadding = EdgeInsets.only(
     left: 16,
     right: 12,
@@ -217,6 +227,7 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
     final hasHeader = label != null || widget.onCopy != null;
 
     final padding = widget.padding ?? _bodyPadding;
+    final touch = FlowTouchTarget.isTouch(context);
     final code = SelectableText.rich(span);
     final body = widget.wrap
         ? Padding(padding: padding, child: code)
@@ -256,19 +267,27 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
             if (hasHeader)
               Container(
                 height: _headerHeight,
-                padding: _headerPadding,
+                padding: touch ? _headerPaddingTouch : _headerPadding,
                 child: Row(
+                  crossAxisAlignment: touch
+                      ? CrossAxisAlignment.start
+                      : CrossAxisAlignment.center,
                   children: [
                     Expanded(
                       child: label == null
                           ? const SizedBox.shrink()
-                          : Text(
-                              label,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: typography.labelMedium
-                                  .copyWith(color: colors.onSurfaceMuted)
-                                  .merge(style?.headerStyle),
+                          : Padding(
+                              padding: EdgeInsets.only(
+                                top: touch ? _labelTop : 0,
+                              ),
+                              child: Text(
+                                label,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: typography.labelMedium
+                                    .copyWith(color: colors.onSurfaceMuted)
+                                    .merge(style?.headerStyle),
+                              ),
                             ),
                     ),
                     if (showCopy)
@@ -344,6 +363,11 @@ class _CopyButtonState extends State<_CopyButton> {
   /// menu rows keep to their card.
   static const BorderRadius _frameRadius = BorderRadius.all(Radius.circular(6));
 
+  /// The header's height as the reach on touch platforms, the frame seated
+  /// where the header's 10 top inset and centring put it.
+  static const double _touch = 36;
+  static const double _touchTopShare = 11 / 12;
+
   bool _hovered = false;
 
   @override
@@ -384,6 +408,11 @@ class _CopyButtonState extends State<_CopyButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return FlowTouchTarget(child: button);
+    return FlowTouchTarget(
+      minWidth: _touch,
+      minHeight: _touch,
+      topShare: _touchTopShare,
+      child: button,
+    );
   }
 }

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -10,6 +10,8 @@ import '../styles/flow_composer_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_attachment_intake.dart';
 import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
+import '../utils/flow_touch_target.dart';
 import '../utils/flow_clipboard_paste.dart';
 import '../utils/flow_file_picker.dart';
 import '../utils/flow_gradient_outline.dart';
@@ -99,6 +101,8 @@ class FlowComposer extends StatefulWidget {
     this.onAttachmentTap,
     this.removeAttachmentTooltip,
     this.previewCloseTooltip,
+    this.sendTooltip,
+    this.stopTooltip,
     this.onAttach,
     this.onAttachmentsPicked,
     this.onAttachmentsDropped,
@@ -275,6 +279,14 @@ class FlowComposer extends StatefulWidget {
   /// Host-localized label for the attach button; also its accessible
   /// name.
   final String? attachTooltip;
+
+  /// Host-localized label for the send disc; also its accessible name.
+  /// Without one assistive tech announces an unnamed button.
+  final String? sendTooltip;
+
+  /// Host-localized label for the stop disc while streaming; also its
+  /// accessible name.
+  final String? stopTooltip;
 
   /// Raises the error banner: the design's tab above the card, in the
   /// error wash with a warning glyph and this line. Null draws nothing.
@@ -670,7 +682,7 @@ class _FlowComposerState extends State<FlowComposer> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 
   Widget _buildSendStopButton(BuildContext context) {
@@ -687,6 +699,7 @@ class _FlowComposerState extends State<FlowComposer> {
           background: discColor,
           foreground: glyphColor,
           padding: _stopPadding,
+          tooltip: widget.stopTooltip,
           onTap: widget.onStop,
         ),
       );
@@ -695,26 +708,29 @@ class _FlowComposerState extends State<FlowComposer> {
       valueListenable: _controller,
       builder: (context, value, _) {
         final canSend = _canSend(value.text.trim());
-        return _ringed(
-          context,
-          active: canSend,
-          disc: Material(
-            // Disabled keeps the arrow's ink and only drains the disc:
-            // primary gives way to the 30% disabled wash.
-            color: canSend ? discColor : colors.onSurfaceDisabled,
-            shape: const CircleBorder(),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: canSend ? _send : null,
-              customBorder: const CircleBorder(),
-              child: CustomPaint(
-                // The design's arrow is a thin stroke, not the chunky
-                // Material glyph.
-                painter: _ArrowUpPainter(color: glyphColor),
-              ),
+        final sendTooltip = widget.sendTooltip;
+        Widget disc = Material(
+          // Disabled keeps the arrow's ink and only drains the disc:
+          // primary gives way to the 30% disabled wash.
+          color: canSend ? discColor : colors.onSurfaceDisabled,
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: canSend ? _send : null,
+            customBorder: const CircleBorder(),
+            child: CustomPaint(
+              // The design's arrow is a thin stroke, not the chunky
+              // Material glyph.
+              painter: _ArrowUpPainter(color: glyphColor),
             ),
           ),
         );
+        // Tooltip contributes the accessible name too, per the attach
+        // button's precedent.
+        if (sendTooltip != null) {
+          disc = Tooltip(message: sendTooltip, child: disc);
+        }
+        return _ringed(context, active: canSend, disc: disc);
       },
     );
   }
@@ -813,22 +829,24 @@ class _FlowComposerState extends State<FlowComposer> {
     // The banner sits above the card and outside the drop target: it is
     // not somewhere to drop a file. AnimatedSize grows it in from the
     // card's top edge, so the thread above eases up rather than jumping.
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        AnimatedSize(
-          duration: MediaQuery.disableAnimationsOf(context)
-              ? Duration.zero
-              : _errorReveal,
-          curve: Curves.easeOut,
-          alignment: Alignment.bottomCenter,
-          child: errorMessage == null
-              ? const SizedBox.shrink()
-              : _buildErrorBanner(context, errorMessage),
-        ),
-        _buildCard(context),
-      ],
+    return FlowSelectionTheme(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          AnimatedSize(
+            duration: MediaQuery.disableAnimationsOf(context)
+                ? Duration.zero
+                : _errorReveal,
+            curve: Curves.easeOut,
+            alignment: Alignment.bottomCenter,
+            child: errorMessage == null
+                ? const SizedBox.shrink()
+                : _buildErrorBanner(context, errorMessage),
+          ),
+          _buildCard(context),
+        ],
+      ),
     );
   }
 

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -625,6 +625,7 @@ class _FlowComposerState extends State<FlowComposer> {
     BuildContext context, {
     required bool active,
     required Widget disc,
+    required VoidCallback? onTap,
   }) {
     final colors = context.flowColors;
     final style = _styleOf(context);
@@ -632,21 +633,27 @@ class _FlowComposerState extends State<FlowComposer> {
     return FlowTouchTarget(
       minWidth: _buttonFrame,
       minHeight: _rowTouch,
-      child: Container(
-        width: _buttonFrame,
-        height: _buttonFrame,
-        alignment: Alignment.center,
-        decoration: ShapeDecoration(
-          color: style?.backgroundColor ?? colors.surfaceBright,
-          shape: CircleBorder(
-            side: BorderSide(
-              color: active
-                  ? (style?.sendBackgroundColor ?? colors.primary)
-                  : colors.outlineVariant,
+      child: GestureDetector(
+        // The ring around the disc is the button too: a tap on it, or
+        // one the reach lands on the frame, fires without the ink.
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: _buttonFrame,
+          height: _buttonFrame,
+          alignment: Alignment.center,
+          decoration: ShapeDecoration(
+            color: style?.backgroundColor ?? colors.surfaceBright,
+            shape: CircleBorder(
+              side: BorderSide(
+                color: active
+                    ? (style?.sendBackgroundColor ?? colors.primary)
+                    : colors.outlineVariant,
+              ),
             ),
           ),
+          child: SizedBox.square(dimension: _buttonDisc, child: disc),
         ),
-        child: SizedBox.square(dimension: _buttonDisc, child: disc),
       ),
     );
   }
@@ -715,6 +722,7 @@ class _FlowComposerState extends State<FlowComposer> {
       return _ringed(
         context,
         active: true,
+        onTap: widget.onStop,
         disc: FlowCircleButton(
           icon: Icons.stop_rounded,
           background: discColor,
@@ -751,7 +759,12 @@ class _FlowComposerState extends State<FlowComposer> {
         if (sendTooltip != null) {
           disc = Tooltip(message: sendTooltip, child: disc);
         }
-        return _ringed(context, active: canSend, disc: disc);
+        return _ringed(
+          context,
+          active: canSend,
+          onTap: canSend ? _send : null,
+          disc: disc,
+        );
       },
     );
   }

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -635,8 +635,11 @@ class _FlowComposerState extends State<FlowComposer> {
       minHeight: _rowTouch,
       child: GestureDetector(
         // The ring around the disc is the button too: a tap on it, or
-        // one the reach lands on the frame, fires without the ink.
+        // one the reach lands on the frame, fires without the ink. Out of
+        // the semantics tree: the disc's own button node carries the
+        // name, and a second tap node beside it would announce unnamed.
         behavior: HitTestBehavior.opaque,
+        excludeFromSemantics: true,
         onTap: onTap,
         child: Container(
           width: _buttonFrame,

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -361,11 +361,14 @@ class _FlowComposerState extends State<FlowComposer> {
   static const double _contentInset = 18;
   static const double _actionInset = 10;
 
-  /// The attach glyph's reach on touch platforms: the row's own 40, the
-  /// send disc's height, so it costs no height, and 4 a side in width,
-  /// taken from the row inset so the glyph draws where it did.
-  static const double _attachTouch = 40;
-  static const double _attachTouchSlack = 4;
+  /// The action row's reach on touch platforms: the attach glyph and the
+  /// send disc stay their drawn 32 wide and take 40 tall, the row growing
+  /// 4 each way into the field gap above and the card's bottom padding
+  /// below, so the card keeps its height and nothing moves.
+  static const double _rowTouch = 40;
+  static const double _rowTouchGrowth = (_rowTouch - _buttonFrame) / 2;
+  static const EdgeInsetsGeometry _cardPaddingTouch =
+      EdgeInsetsDirectional.fromSTEB(1, 19, 1, 11 - _rowTouchGrowth);
 
   /// The error tab's cross takes the tab's 30 on touch platforms.
   static const double _errorDismissTouch = 30;
@@ -625,21 +628,26 @@ class _FlowComposerState extends State<FlowComposer> {
   }) {
     final colors = context.flowColors;
     final style = _styleOf(context);
-    return Container(
-      width: _buttonFrame,
-      height: _buttonFrame,
-      alignment: Alignment.center,
-      decoration: ShapeDecoration(
-        color: style?.backgroundColor ?? colors.surfaceBright,
-        shape: CircleBorder(
-          side: BorderSide(
-            color: active
-                ? (style?.sendBackgroundColor ?? colors.primary)
-                : colors.outlineVariant,
+    // The disc keeps its 32 frame and takes the row's 40 on touch.
+    return FlowTouchTarget(
+      minWidth: _buttonFrame,
+      minHeight: _rowTouch,
+      child: Container(
+        width: _buttonFrame,
+        height: _buttonFrame,
+        alignment: Alignment.center,
+        decoration: ShapeDecoration(
+          color: style?.backgroundColor ?? colors.surfaceBright,
+          shape: CircleBorder(
+            side: BorderSide(
+              color: active
+                  ? (style?.sendBackgroundColor ?? colors.primary)
+                  : colors.outlineVariant,
+            ),
           ),
         ),
+        child: SizedBox.square(dimension: _buttonDisc, child: disc),
       ),
-      child: SizedBox.square(dimension: _buttonDisc, child: disc),
     );
   }
 
@@ -692,8 +700,8 @@ class _FlowComposerState extends State<FlowComposer> {
       button = Tooltip(message: tooltip, child: button);
     }
     return FlowTouchTarget(
-      minWidth: _attachTouch,
-      minHeight: _attachTouch,
+      minWidth: _buttonFrame,
+      minHeight: _rowTouch,
       child: button,
     );
   }
@@ -758,7 +766,11 @@ class _FlowComposerState extends State<FlowComposer> {
     final foreground = style?.errorForegroundColor ?? colors.onErrorContainer;
     final icon = widget.errorIcon;
     final onDismiss = widget.onErrorDismiss;
-    const dismissDisc = _errorDismissIconSize + _errorDismissPadding * 2;
+    // On touch the cross reaches the tab's 30, which the padding then
+    // gives up entirely, so the tab keeps its height either way.
+    final dismissDisc = FlowTouchTarget.isTouch(context)
+        ? _errorDismissTouch
+        : _errorDismissIconSize + _errorDismissPadding * 2;
     final verticalPadding = onDismiss == null
         ? _errorVerticalPadding
         : _errorVerticalPadding - (dismissDisc - _errorIconSize) / 2;
@@ -869,6 +881,7 @@ class _FlowComposerState extends State<FlowComposer> {
   Widget _buildCard(BuildContext context) {
     final colors = context.flowColors;
     final typography = context.flowTypography;
+    final touch = FlowTouchTarget.isTouch(context);
 
     final active = widget.enabled && (_focused || _hovered);
     final radius = widget.borderRadius ?? _cardRadius;
@@ -964,7 +977,9 @@ class _FlowComposerState extends State<FlowComposer> {
                     BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
                   ],
                 ),
-                padding: widget.padding ?? _cardPadding,
+                padding:
+                    widget.padding ??
+                    (touch ? _cardPaddingTouch : _cardPadding),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1040,12 +1055,12 @@ class _FlowComposerState extends State<FlowComposer> {
                         ),
                       ),
                     ),
-                    const SizedBox(height: _fieldGap),
+                    SizedBox(
+                      height: touch ? _fieldGap - _rowTouchGrowth : _fieldGap,
+                    ),
                     Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: FlowTouchTarget.isTouch(context)
-                            ? _actionInset - _attachTouchSlack
-                            : _actionInset,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: _actionInset,
                       ),
                       child: Row(
                         children: [

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -360,6 +360,15 @@ class _FlowComposerState extends State<FlowComposer> {
   );
   static const double _contentInset = 18;
   static const double _actionInset = 10;
+
+  /// The attach glyph's reach on touch platforms: the row's own 40, the
+  /// send disc's height, so it costs no height, and 4 a side in width,
+  /// taken from the row inset so the glyph draws where it did.
+  static const double _attachTouch = 40;
+  static const double _attachTouchSlack = 4;
+
+  /// The error tab's cross takes the tab's 30 on touch platforms.
+  static const double _errorDismissTouch = 30;
   static const double _attachmentGap = 12;
   static const double _fieldGap = 16;
   static const double _leadingGap = 4;
@@ -682,7 +691,11 @@ class _FlowComposerState extends State<FlowComposer> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return FlowTouchTarget(child: button);
+    return FlowTouchTarget(
+      minWidth: _attachTouch,
+      minHeight: _attachTouch,
+      child: button,
+    );
   }
 
   Widget _buildSendStopButton(BuildContext context) {
@@ -812,6 +825,7 @@ class _FlowComposerState extends State<FlowComposer> {
                       hoverColor: background,
                       iconSize: _errorDismissIconSize,
                       padding: _errorDismissPadding,
+                      touchMinSize: _errorDismissTouch,
                       tooltip: widget.errorDismissTooltip,
                       onTap: onDismiss,
                     ),
@@ -1028,8 +1042,10 @@ class _FlowComposerState extends State<FlowComposer> {
                     ),
                     const SizedBox(height: _fieldGap),
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: _actionInset,
+                      padding: EdgeInsets.symmetric(
+                        horizontal: FlowTouchTarget.isTouch(context)
+                            ? _actionInset - _attachTouchSlack
+                            : _actionInset,
                       ),
                       child: Row(
                         children: [

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -4,6 +4,7 @@ import '../styles/flow_menu_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_menu_core.dart';
 import '../utils/flow_menu_sheet.dart';
+import '../utils/flow_touch_target.dart';
 
 /// One entry in a [FlowMenu]: an option or a divider.
 @immutable
@@ -278,7 +279,7 @@ class _FlowMenuState extends State<FlowMenu> {
         if (tooltip != null) {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
-        return trigger;
+        return FlowTouchTarget(child: trigger);
       },
     );
   }

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -129,6 +129,9 @@ class _FlowMenuState extends State<FlowMenu> {
   static const double _triggerIconSize = 18;
   static const double _triggerPadding = 7;
 
+  /// The trigger's reach on touch platforms: the composer row's 40.
+  static const double _triggerTouch = 40;
+
   bool _hovered = false;
 
   bool get _hasOptions => widget.entries.whereType<FlowMenuOption>().isNotEmpty;
@@ -279,7 +282,11 @@ class _FlowMenuState extends State<FlowMenu> {
         if (tooltip != null) {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
-        return FlowTouchTarget(child: trigger);
+        return FlowTouchTarget(
+          minWidth: _triggerTouch,
+          minHeight: _triggerTouch,
+          child: trigger,
+        );
       },
     );
   }

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -129,8 +129,9 @@ class _FlowMenuState extends State<FlowMenu> {
   static const double _triggerIconSize = 18;
   static const double _triggerPadding = 7;
 
-  /// The trigger's reach on touch platforms: the composer row's 40.
-  static const double _triggerTouch = 40;
+  /// The trigger's reach on touch platforms: its drawn 32 wide, the
+  /// composer row's 40 tall, so a rail of triggers never shifts.
+  static const double _triggerTouchHeight = 40;
 
   bool _hovered = false;
 
@@ -283,8 +284,8 @@ class _FlowMenuState extends State<FlowMenu> {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
         return FlowTouchTarget(
-          minWidth: _triggerTouch,
-          minHeight: _triggerTouch,
+          minWidth: _triggerIconSize + _triggerPadding * 2,
+          minHeight: _triggerTouchHeight,
           child: trigger,
         );
       },

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
@@ -195,14 +197,22 @@ class FlowMessage extends StatelessWidget {
 
   bool get _isError => message.status == FlowMessageStatus.error;
 
-  /// The gap above the footer, less the reach a [FlowMessageActions] strip
-  /// takes above its frames on touch platforms: the strip grows up into
-  /// the gap and the frames draw where the design put them.
-  double _footerGap(BuildContext context, double gap) {
+  /// The footer under its gap. A [FlowMessageActions] strip on touch
+  /// platforms reaches up into the gap instead: the strip grows by what
+  /// the gap holds, the gap shrinks by the same, and the frames draw where
+  /// the design put them.
+  Widget _footer(BuildContext context, Widget footer, double gap) {
     if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
-      return gap;
+      return Padding(
+        padding: EdgeInsets.only(top: gap),
+        child: footer,
+      );
     }
-    return (gap - FlowMessageActions.touchReach).clamp(0.0, gap);
+    final reach = math.min(gap, FlowMessageActions.touchReach);
+    return Padding(
+      padding: EdgeInsets.only(top: gap - reach),
+      child: FlowFooterReach(reach: reach, child: footer),
+    );
   }
 
   @override
@@ -272,13 +282,7 @@ class FlowMessage extends StatelessWidget {
                 constraints: BoxConstraints(maxWidth: maxWidth),
                 child: bubble,
               ),
-            if (footer != null)
-              Padding(
-                padding: EdgeInsets.only(
-                  top: _footerGap(context, _userFooterGap),
-                ),
-                child: footer,
-              ),
+            if (footer != null) _footer(context, footer!, _userFooterGap),
           ],
         );
       },
@@ -331,13 +335,7 @@ class FlowMessage extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         content,
-        if (footer != null)
-          Padding(
-            padding: EdgeInsets.only(
-              top: _footerGap(context, _assistantFooterGap),
-            ),
-            child: footer,
-          ),
+        if (footer != null) _footer(context, footer!, _assistantFooterGap),
       ],
     );
 

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -7,11 +7,13 @@ import '../styles/flow_message_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_attachment_error.dart';
 import '../utils/flow_shimmer_sweep.dart';
+import '../utils/flow_touch_target.dart';
 import 'flow_attachment_group.dart';
 import 'flow_attachment_preview.dart';
 import 'flow_code_block.dart';
 import 'flow_error_state.dart';
 import 'flow_markdown.dart';
+import 'flow_message_actions.dart';
 import 'flow_streaming_text.dart';
 import 'flow_thinking_indicator.dart';
 
@@ -193,6 +195,16 @@ class FlowMessage extends StatelessWidget {
 
   bool get _isError => message.status == FlowMessageStatus.error;
 
+  /// The gap above the footer, less the reach a [FlowMessageActions] strip
+  /// takes above its frames on touch platforms: the strip grows up into
+  /// the gap and the frames draw where the design put them.
+  double _footerGap(BuildContext context, double gap) {
+    if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
+      return gap;
+    }
+    return (gap - FlowMessageActions.touchReach).clamp(0.0, gap);
+  }
+
   @override
   Widget build(BuildContext context) {
     return switch (message.role) {
@@ -262,7 +274,9 @@ class FlowMessage extends StatelessWidget {
               ),
             if (footer != null)
               Padding(
-                padding: const EdgeInsets.only(top: _userFooterGap),
+                padding: EdgeInsets.only(
+                  top: _footerGap(context, _userFooterGap),
+                ),
                 child: footer,
               ),
           ],
@@ -319,7 +333,9 @@ class FlowMessage extends StatelessWidget {
         content,
         if (footer != null)
           Padding(
-            padding: const EdgeInsets.only(top: _assistantFooterGap),
+            padding: EdgeInsets.only(
+              top: _footerGap(context, _assistantFooterGap),
+            ),
             child: footer,
           ),
       ],

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -132,7 +132,16 @@ class FlowMessageActions extends StatelessWidget {
           (i == 0 || i == last ? _gap / 2 : _gap);
     }
 
-    double leftShare(int i) => i == 0 ? 0 : (i == last ? 1 : 0.5);
+    // Shares are physical, and a Row mirrors under RTL: the first action
+    // keeps its frame at the strip's start and the last at its end,
+    // whichever side those are.
+    final ltr = Directionality.of(context) == TextDirection.ltr;
+    double leftShare(int i) {
+      if (i == 0) return ltr ? 0 : 1;
+      if (i == last) return ltr ? 1 : 0;
+      return 0.5;
+    }
+
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -2,6 +2,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../styles/flow_message_actions_style.dart';
 import '../theme/flow_theme.dart';
+import '../utils/flow_touch_target.dart';
 
 /// One action in a [FlowMessageActions] row.
 ///
@@ -202,6 +203,14 @@ class _ActionButtonState extends State<_ActionButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    // The row keeps the design's 20px frames on a 4px pitch; a finger
+    // gets the pitch sideways and the design's 44 vertically, mostly
+    // downward into the gap between turns, off the text above.
+    return FlowTouchTarget(
+      minWidth: _frameSize + 4,
+      minHeight: 44,
+      topShare: 0.2,
+      child: button,
+    );
   }
 }

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -93,6 +93,13 @@ class FlowMessageActions extends StatelessWidget {
   /// value, not a scale step.
   static const double _gap = 4;
 
+  /// The strip's reach above its frames on touch platforms: each button
+  /// lays out `touchReach` taller with its frame at the bottom, and
+  /// `FlowMessage` gives up the same 12 of its footer gap, so the frames
+  /// stay put while the strip reaches up into the gap. Sideways each
+  /// takes the strip's pitch.
+  static const double touchReach = 12;
+
   /// Rendered in order.
   final List<FlowMessageAction> actions;
 
@@ -204,12 +211,12 @@ class _ActionButtonState extends State<_ActionButton> {
       button = Tooltip(message: tooltip, child: button);
     }
     // The row keeps the design's 20px frames on a 4px pitch; a finger
-    // gets the pitch sideways and the design's 44 vertically, mostly
-    // downward into the gap between turns, off the text above.
+    // gets the pitch sideways and the footer gap above, the frame seated
+    // at the bottom so it draws where it did.
     return FlowTouchTarget(
-      minWidth: _frameSize + 4,
-      minHeight: 44,
-      topShare: 0.2,
+      minWidth: _frameSize + FlowMessageActions._gap,
+      minHeight: _frameSize + FlowMessageActions.touchReach,
+      topShare: 1,
       child: button,
     );
   }

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -94,10 +94,12 @@ class FlowMessageActions extends StatelessWidget {
   static const double _gap = 4;
 
   /// The strip's reach above its frames on touch platforms: each button
-  /// lays out `touchReach` taller with its frame at the bottom, and
-  /// `FlowMessage` gives up the same 12 of its footer gap, so the frames
-  /// stay put while the strip reaches up into the gap. Sideways each
-  /// takes the strip's pitch.
+  /// lays out this much taller with its frame at the bottom, and
+  /// `FlowMessage` gives up the same run of its footer gap, so the frames
+  /// stay put while the strip reaches up into the gap — or as much of it
+  /// as the gap holds, through [FlowFooterReach]. Sideways the buttons
+  /// share the strip's pitch between them, the edge ones keeping their
+  /// frames flush with the strip's ends.
   static const double touchReach = 12;
 
   /// Rendered in order.
@@ -117,16 +119,31 @@ class FlowMessageActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final effective =
         context.flowTheme.messageActionsStyle?.merge(style) ?? style;
-    // The design's action strip: 15px glyphs on 20px frames, 4 apart.
+    // The design's action strip: 15px glyphs on 20px frames, 4 apart. On
+    // touch the gaps belong to the buttons instead — each edge button
+    // takes half a gap on its outer side, the rest a full gap — so the
+    // pitch and every frame's place are unchanged while a finger between
+    // two frames still lands on one.
+    final touch = FlowTouchTarget.isTouch(context);
+    final last = actions.length - 1;
+    double reachWidth(int i) {
+      if (!touch || last == 0) return _ActionButtonState._frameSize;
+      return _ActionButtonState._frameSize +
+          (i == 0 || i == last ? _gap / 2 : _gap);
+    }
+
+    double leftShare(int i) => i == 0 ? 0 : (i == last ? 1 : 0.5);
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         for (var i = 0; i < actions.length; i++) ...[
-          if (i > 0) const SizedBox(width: _gap),
+          if (i > 0 && !touch) const SizedBox(width: _gap),
           _ActionButton(
             action: actions[i],
             iconSize: iconSize,
             style: effective,
+            reachWidth: reachWidth(i),
+            leftShare: leftShare(i),
           ),
         ],
       ],
@@ -141,11 +158,18 @@ class _ActionButton extends StatefulWidget {
     required this.action,
     required this.iconSize,
     this.style,
+    required this.reachWidth,
+    required this.leftShare,
   });
 
   final FlowMessageAction action;
   final double iconSize;
   final FlowMessageActionsStyle? style;
+
+  /// The button's share of the strip's pitch on touch platforms, and
+  /// where its frame sits in it.
+  final double reachWidth;
+  final double leftShare;
 
   @override
   State<_ActionButton> createState() => _ActionButtonState();
@@ -210,14 +234,33 @@ class _ActionButtonState extends State<_ActionButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    // The row keeps the design's 20px frames on a 4px pitch; a finger
-    // gets the pitch sideways and the footer gap above, the frame seated
-    // at the bottom so it draws where it did.
+    // The frame keeps its place: its share of the pitch sideways, the
+    // footer gap the message gave up above, seated at the bottom.
+    final reach =
+        FlowFooterReach.maybeOf(context) ?? FlowMessageActions.touchReach;
     return FlowTouchTarget(
-      minWidth: _frameSize + FlowMessageActions._gap,
-      minHeight: _frameSize + FlowMessageActions.touchReach,
+      minWidth: widget.reachWidth,
+      minHeight: _frameSize + reach,
       topShare: 1,
+      leftShare: widget.leftShare,
       child: button,
     );
   }
+}
+
+/// How far a [FlowMessageActions] strip may reach above its frames on
+/// touch platforms: the run of footer gap its message has given up.
+/// `FlowMessage` sets it to the gap it has; a strip on its own takes the
+/// full [FlowMessageActions.touchReach].
+class FlowFooterReach extends InheritedWidget {
+  const FlowFooterReach({super.key, required this.reach, required super.child});
+
+  final double reach;
+
+  static double? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<FlowFooterReach>()?.reach;
+
+  @override
+  bool updateShouldNotify(FlowFooterReach oldWidget) =>
+      reach != oldWidget.reach;
 }


### PR DESCRIPTION
## Summary

Mobile fixes from a pass over the example on the iPhone simulator. Stacked on #35 (shared changelog); merge that first.

- **Touch targets.** Message actions sit on a 20px frame, the attach, stop, remove and error-dismiss discs on 24 to 32px, the menu triggers on 32, the code block's copy on 24. A finger needs 44 (Apple) to 48 (Material). New `FlowTouchTarget` widens the hit area on touch platforms without changing layout, sized per site so a neighbour's taps stay its own (siblings hit-test in reverse order, not by distance; the actions row takes its reach downward into the gap between turns). Pointer platforms pass straight through.
- **Send and stop names.** The discs had no accessible name; VoiceOver announced an unnamed button. `FlowComposer.sendTooltip` and `stopTooltip` name them, as tooltips, which carry the semantics label. Docs and example updated.
- **Caret and selection colour.** Nothing set them, so a host installing `FlowTheme` on a stock `ThemeData` got Material's purple caret, wash and iOS handles against Flow's primary. New `FlowSelectionTheme` derives `TextSelectionTheme` and the Cupertino primary from `FlowColors`; wraps the chat view and the composer.
- The example gates its web-only drop and paste callbacks with `kIsWeb`, which silences the two runtime warnings it logged on iOS.

## Screenshots

| Before | After |
| --- | --- |
| Purple caret in the composer (screenshots attached separately) | Caret in the Flow primary |

## How this was verified

- iPhone 17 Pro simulator, example app, light and dark: caret colour after hot reload; layout unchanged around the message actions, composer row and code block header; XXXL Dynamic Type still lays out.
- `flutter analyze` clean at the root and in `example/` and `playground/`; `dart format .` applied.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/a11y and layout hit-testing on touch; no auth, data, or breaking API beyond optional composer tooltip params.
> 
> **Overview**
> Improves **mobile usability and accessibility** without shifting desktop layout: new **`FlowTouchTarget`** (iOS/Android only) reserves larger hit boxes in layout and forwards taps to small controls—message actions, composer attach/send/stop rings, menu triggers, code-block copy, and error dismiss—often by **reclaiming footer/row gap** so pixels stay on-spec.
> 
> Adds **`FlowComposer.sendTooltip`** and **`stopTooltip`** so VoiceOver gets names for send/stop (documented in composer docs; example sets `'Send'` / `'Stop'`). **`FlowSelectionTheme`** wraps the chat surface and composer so caret, selection wash, handles, and Cupertino primary use **Flow primary** instead of the host `ColorScheme` purple.
> 
> The example passes **`kIsWeb`**-gated drop/paste handlers to avoid iOS runtime warnings. **`CHANGELOG.md`** records touch targets, tooltips, and the caret fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4bad4cc67257233eee1f51fe953e9d00e279e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->