### PR TITLE
feat: message menu, selectable prose, and the phone and settle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,11 +206,12 @@
 
 - **Touch targets** — the message actions, the composer's attach glyph
   and error-dismiss cross, the menu triggers and the code block's copy
-  affordance take a finger's reach on phones: the actions strip the
-  row's pitch wide by 32 tall on its 20px frames, the attach and menu
-  triggers 40, the copy 36, the dismiss 30, each reserved in layout and
-  absorbed from the gap beside it, so the drawn frames stay where the
-  design put them. Pointer platforms are untouched.
+  affordance take a finger's reach on phones: the actions strip its
+  pitch wide and the footer gap taller on its 20px frames, the attach,
+  menu and send discs the row's 40 tall, the copy 36, the dismiss 30,
+  each reserved in layout and absorbed from the gap beside it, so the
+  drawn frames stay where the design put them. Pointer platforms are
+  untouched.
 - **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
   name the discs for assistive tech; before, both announced as unnamed
   buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,19 @@
   position back into range, on every metrics change and scroll end, and
   creates its own controller when the host passes none.
 
+- **Touch targets** — the message actions, the composer's attach and
+  stop discs, the attachment tile's cross, the error tab's cross, the
+  menu triggers and the code block's copy affordance now accept a finger
+  from a 44px reach on phones, sized per site so a neighbour's taps stay
+  its own, with the drawn frames unchanged. Pointer platforms are
+  untouched.
+- **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
+  name the discs for assistive tech; before, both announced as unnamed
+  buttons.
+- **Fix** — the caret, selection wash and handles across the chat view
+  and the composer take the Flow primary rather than the host
+  `ColorScheme`'s, which on a stock `ThemeData` was Material's purple.
+
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,16 @@
   body and the inline span, drop from 14 to 13 on their 1.6 and 1.5
   lines.
 
+- **Fix** — the thread no longer strands at a scroll offset outside its
+  range: the newest message clipped under the list's bottom edge with
+  blank space beneath, or a blank band above the oldest. Flutter keeps an
+  offset that has left the range — a drag that dismisses the keyboard
+  grows the viewport mid-gesture while a reply is still growing — and
+  only the next gesture pulled it back. `FlowThread` now clamps an idle
+  position back into range, on every metrics change and scroll end, and
+  creates its own controller when the host passes none.
+
+
 ## 0.2.0
 
 - **Typography** — title and label roles now carry an emphasised cut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,8 +233,8 @@
   conversation a `SelectionArea` on pointer platforms: drag across turns,
   copy with the shortcut, the message menu still on right-click. Phones
   select from the menu: `showFlowTextSelection` pushes a full-screen page
-  of a message's text for the platform's handles, and
-  `FlowMessageData.plainText` is the text to hand it.
+  of a message, typeset as it was in the thread, for the platform's
+  handles; `FlowMessageData.plainText` joins its text for a copy.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,12 +204,13 @@
   position back into range, on every metrics change and scroll end, and
   creates its own controller when the host passes none.
 
-- **Touch targets** — the message actions, the composer's attach and
-  stop discs, the attachment tile's cross, the error tab's cross, the
-  menu triggers and the code block's copy affordance now accept a finger
-  from a 44px reach on phones, sized per site so a neighbour's taps stay
-  its own, with the drawn frames unchanged. Pointer platforms are
-  untouched.
+- **Touch targets** — the message actions, the composer's attach glyph
+  and error-dismiss cross, the menu triggers and the code block's copy
+  affordance take a finger's reach on phones: the actions strip the
+  row's pitch wide by 32 tall on its 20px frames, the attach and menu
+  triggers 40, the copy 36, the dismiss 30, each reserved in layout and
+  absorbed from the gap beside it, so the drawn frames stay where the
+  design put them. Pointer platforms are untouched.
 - **Send and stop names** — `FlowComposer.sendTooltip` and `stopTooltip`
   name the discs for assistive tech; before, both announced as unnamed
   buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,22 @@
   and the composer take the Flow primary rather than the host
   `ColorScheme`'s, which on a stock `ThemeData` was Material's purple.
 
+- **Message menu** — the AI apps' long-press. `FlowThread.messageMenu`
+  hands back a message's entries (`FlowMenuOption`s and dividers, labels
+  the host's) and `onMessageMenuSelected` reports the pick with its
+  message; `FlowMessage` takes the pair as `menuEntries` and
+  `onMenuSelected`. A long-press with a haptic on touch, a right-click on
+  pointer platforms; the phone sheet or a popover at the pointer, by the
+  theme's platform like the other menus. The example offers copy,
+  feedback, regenerate and delete; the playground's thread stage gains a
+  Long-press menu variant.
+
+- **Selecting text** — `FlowThread.selectable` (on by default) makes the
+  conversation a `SelectionArea` on pointer platforms: drag across turns,
+  copy with the shortcut, the message menu still on right-click. Phones
+  select from the menu: `showFlowTextSelection` pushes a full-screen page
+  of a message's text for the platform's handles, and
+  `FlowMessageData.plainText` is the text to hand it.
 
 ## 0.2.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Values come from the Flow UI Figma file. Role names follow Material 3's `ColorSc
 
 | # | Component | Variants / notes | Status |
 |---|-----------|------------------|--------|
-| 8 | Message & Thread | ink-wash user bubble; plain assistant | ✅ |
+| 8 | Message & Thread | ink-wash user bubble; plain assistant; long-press menu; selectable prose | ✅ |
 | 9 | Thread List | host-labeled sections; unread dot, pinned glyph, leading icon slot; single selection by id | ✅ |
 | 10 | Message actions | | ✅ |
 | 11 | Streaming text | | ✅ |

--- a/docs/src/content/docs/components/composer.mdx
+++ b/docs/src/content/docs/components/composer.mdx
@@ -369,6 +369,9 @@ wins field by field.
   `errorMessage` + `errorIcon` — the error banner above the card;
   `onErrorDismiss` + `errorDismissTooltip` draw its cross.
   `onContentInserted` — Android keyboard media insertion.
+- `sendTooltip`, `stopTooltip` — host-localized names for the send and
+  stop discs, and their accessible names; without them assistive tech
+  announces an unnamed button.
 - `controller`, `focusNode`, `placeholder` — the field itself; pass your
   own `TextEditingController` to prefill or clear the draft.
   `placeholder` defaults to 'How can I help you today?' — the one string

--- a/docs/src/content/docs/components/message-thread.mdx
+++ b/docs/src/content/docs/components/message-thread.mdx
@@ -93,6 +93,55 @@ FlowMessage(
 )
 ```
 
+## Message menu
+
+The AI apps' long-press. `messageMenu` hands back the entries for a
+message — options and dividers like `FlowMenu.entries`, labels yours —
+and `onMessageMenuSelected` reports the chosen id with the message it was
+opened on. A long-press opens it with a haptic on touch and a right-click
+on pointer platforms: a sheet on phones, a popover at the pointer
+elsewhere, resolved by the theme's platform like the other menus. Return
+an empty list for a message that should have none, a turn still
+streaming, say. Long-presses inside a code block keep selecting text.
+
+```dart title="Copy, regenerate, delete"
+FlowThread(
+  messages: messages,
+  messageMenu: (message) => [
+    FlowMenuOption(id: 'copy', icon: Icons.copy_outlined, label: 'Copy'),
+    if (message.role == FlowMessageRole.assistant)
+      FlowMenuOption(id: 'again', icon: Icons.refresh, label: 'Regenerate'),
+    FlowMenuDivider(),
+    FlowMenuOption(id: 'delete', icon: Icons.delete_outline, label: 'Delete'),
+  ],
+  onMessageMenuSelected: (message, id) => handle(message, id),
+)
+```
+
+`FlowMessage` takes the same pair as `menuEntries` and `onMenuSelected`
+when used on its own.
+
+## Selecting text
+
+On pointer platforms the thread is a `SelectionArea` by default
+(`selectable`): drag across turns, copy with the platform shortcut. The
+messages' own gestures sit below it, so a right-click still opens the
+message menu. Phones can't have both, since there the long-press *is*
+the menu, so they select from it: `showFlowTextSelection` pushes a
+full-screen page of the message's `plainText` where a long-press selects
+a word and the platform's handles take over.
+
+```dart title="Select text from the menu"
+onMessageMenuSelected: (message, id) => switch (id) {
+  'select' => showFlowTextSelection(
+    context: context,
+    text: message.plainText,
+    closeTooltip: 'Close',
+  ),
+  _ => handle(message, id),
+},
+```
+
 ## Message parts
 
 Message content is typed parts, not strings: a sealed `FlowMessagePart`

--- a/docs/src/content/docs/components/message-thread.mdx
+++ b/docs/src/content/docs/components/message-thread.mdx
@@ -128,14 +128,14 @@ On pointer platforms the thread is a `SelectionArea` by default
 messages' own gestures sit below it, so a right-click still opens the
 message menu. Phones can't have both, since there the long-press *is*
 the menu, so they select from it: `showFlowTextSelection` pushes a
-full-screen page of the message's `plainText` where a long-press selects
-a word and the platform's handles take over.
+full-screen page of the message, typeset as it was in the thread, where a
+long-press selects a word and the platform's handles take over.
 
 ```dart title="Select text from the menu"
 onMessageMenuSelected: (message, id) => switch (id) {
   'select' => showFlowTextSelection(
     context: context,
-    text: message.plainText,
+    message: message,
     closeTooltip: 'Close',
   ),
   _ => handle(message, id),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flow_ui/flow_ui.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -462,7 +463,9 @@ class _ChatScreenState extends State<ChatScreen> {
         // Drag-and-drop, handled by the package. Web only — the SDK
         // implements OS file drop nowhere else — and a no-op elsewhere,
         // which is why the attach button carries the same job.
-        onAttachmentsDropped: _addAttachments,
+        // Web only: the SDK implements OS file drop nowhere else, and the
+        // package says so at runtime when handed the callback elsewhere.
+        onAttachmentsDropped: kIsWeb ? _addAttachments : null,
         onAttachmentRejected: _rejectAttachment,
         attachmentOptions: _attachmentOptions,
         dropLabel: 'Drop files to add to chat',
@@ -496,9 +499,11 @@ class _ChatScreenState extends State<ChatScreen> {
           isStreaming: _generating,
           onSend: _send,
           onStop: _stop,
+          sendTooltip: 'Send',
+          stopTooltip: 'Stop',
           // Picking goes through the "+" menu below; paste and drop land
           // in the same place — three ways in, one handler.
-          onAttachmentsPasted: _addAttachments,
+          onAttachmentsPasted: kIsWeb ? _addAttachments : null,
           onAttachmentRejected: _rejectAttachment,
           attachmentOptions: _attachmentOptions,
           // The design's error banner above the card; the words are this

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -429,6 +429,90 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
+  /// The context menu's entries: nothing while a turn is still coming
+  /// in, copy and delete for the user's own, the actions row's set for a
+  /// settled reply.
+  List<FlowMenuEntry> _menuFor(FlowMessageData message) {
+    if (message.status == FlowMessageStatus.pending ||
+        message.status == FlowMessageStatus.streaming) {
+      return const [];
+    }
+    final feedback = _feedback[message.id];
+    return [
+      const FlowMenuOption(
+        id: 'copy',
+        icon: Icons.copy_outlined,
+        label: 'Copy',
+      ),
+      const FlowMenuOption(
+        id: 'select',
+        icon: Icons.text_fields,
+        label: 'Select text',
+      ),
+      if (message.role == FlowMessageRole.assistant) ...[
+        FlowMenuOption(
+          id: 'up',
+          icon: Icons.thumb_up_outlined,
+          label: 'Good response',
+          selected: feedback == true,
+        ),
+        FlowMenuOption(
+          id: 'down',
+          icon: Icons.thumb_down_outlined,
+          label: 'Bad response',
+          selected: feedback == false,
+        ),
+        FlowMenuOption(
+          id: 'regenerate',
+          icon: Icons.refresh,
+          label: 'Regenerate',
+          enabled: !_generating && message.id == _messages.last.id,
+        ),
+      ],
+      const FlowMenuDivider(),
+      const FlowMenuOption(
+        id: 'delete',
+        icon: Icons.delete_outline,
+        label: 'Delete',
+      ),
+    ];
+  }
+
+  void _onMenu(FlowMessageData message, String id) {
+    switch (id) {
+      case 'copy':
+        _copy(message);
+      case 'select':
+        showFlowTextSelection(
+          context: context,
+          text: message.plainText,
+          closeTooltip: 'Close',
+        );
+      case 'up':
+        setState(() {
+          _feedback[message.id] == true
+              ? _feedback.remove(message.id)
+              : _feedback[message.id] = true;
+        });
+      case 'down':
+        setState(() {
+          _feedback[message.id] == false
+              ? _feedback.remove(message.id)
+              : _feedback[message.id] = false;
+        });
+      case 'regenerate':
+        _retry(message);
+      case 'delete':
+        setState(() {
+          _feedback.remove(message.id);
+          _messages = [
+            for (final m in _messages)
+              if (m.id != message.id) m,
+          ];
+        });
+    }
+  }
+
   /// Retry from the thread's error card: drop the failed reply, re-run.
   void _retry(FlowMessageData message) {
     if (_generating) return;
@@ -492,6 +576,10 @@ class _ChatScreenState extends State<ChatScreen> {
           // The footer slot keeps the default message and its wiring;
           // only the actions row is the host's.
           messageFooter: _actionsFor,
+          // The long-press menu: the same intents as the actions row,
+          // reachable from anywhere on the message, plus delete.
+          messageMenu: _menuFor,
+          onMessageMenuSelected: _onMenu,
         ),
         threadController: _scroll,
         jumpToLatestTooltip: 'Jump to latest',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -485,7 +485,7 @@ class _ChatScreenState extends State<ChatScreen> {
       case 'select':
         showFlowTextSelection(
           context: context,
-          text: message.plainText,
+          message: message,
           closeTooltip: 'Close',
         );
       case 'up':

--- a/lib/flow_ui.dart
+++ b/lib/flow_ui.dart
@@ -50,6 +50,7 @@ export 'src/widgets/flow_streaming_text.dart';
 export 'src/widgets/flow_suggestion.dart';
 export 'src/styles/flow_suggestion_style.dart';
 export 'src/widgets/flow_thinking_indicator.dart';
+export 'src/widgets/flow_text_selection.dart';
 export 'src/widgets/flow_thread.dart';
 export 'src/widgets/flow_thread_list.dart';
 export 'src/styles/flow_thread_list_style.dart';

--- a/lib/src/models/flow_message_data.dart
+++ b/lib/src/models/flow_message_data.dart
@@ -79,4 +79,16 @@ class FlowMessageData {
       timestamp: timestamp ?? this.timestamp,
     );
   }
+
+  /// The message as text: text parts and code in order, a blank line
+  /// between them, attachments and images left out — what a copy or a
+  /// select-text page carries.
+  String get plainText => [
+    for (final part in parts)
+      switch (part) {
+        FlowTextPart() => part.text,
+        FlowCodePart() => part.code,
+        _ => null,
+      },
+  ].nonNulls.join('\n\n');
 }

--- a/lib/src/utils/flow_circle_button.dart
+++ b/lib/src/utils/flow_circle_button.dart
@@ -1,5 +1,7 @@
 import 'package:material_ui/material_ui.dart';
 
+import 'flow_touch_target.dart';
+
 // Internal chrome shared by the composer, the attachment tiles and the
 // attachment preview. Not exported from the package barrel.
 
@@ -75,6 +77,6 @@ class FlowCircleButton extends StatelessWidget {
     if (message != null) {
       button = Tooltip(message: message, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 }

--- a/lib/src/utils/flow_circle_button.dart
+++ b/lib/src/utils/flow_circle_button.dart
@@ -26,6 +26,7 @@ class FlowCircleButton extends StatelessWidget {
     this.iconSize = 18,
     this.padding,
     this.hoverColor,
+    this.touchMinSize = 0,
   });
 
   final IconData icon;
@@ -52,6 +53,10 @@ class FlowCircleButton extends StatelessWidget {
   /// [background] — the right behaviour when the disc is translucent.
   final Color? hoverColor;
 
+  /// A finger's reach on touch platforms, reserved square in layout; zero
+  /// leaves the disc its drawn size. Sites pass what they can hold.
+  final double touchMinSize;
+
   @override
   Widget build(BuildContext context) {
     Widget button = Material(
@@ -77,6 +82,11 @@ class FlowCircleButton extends StatelessWidget {
     if (message != null) {
       button = Tooltip(message: message, child: button);
     }
-    return FlowTouchTarget(child: button);
+    if (touchMinSize <= 0) return button;
+    return FlowTouchTarget(
+      minWidth: touchMinSize,
+      minHeight: touchMinSize,
+      child: button,
+    );
   }
 }

--- a/lib/src/utils/flow_menu_entries.dart
+++ b/lib/src/utils/flow_menu_entries.dart
@@ -1,0 +1,115 @@
+import 'package:material_ui/material_ui.dart';
+
+import '../styles/flow_menu_style.dart';
+import '../theme/flow_theme.dart';
+import '../widgets/flow_menu.dart'
+    show FlowMenuDivider, FlowMenuEntry, FlowMenuOption;
+import 'flow_menu_core.dart';
+import 'flow_menu_sheet.dart';
+
+/// The rows an anchored menu card draws for [entries]: options as
+/// [FlowMenuRow]s, dividers as rules, options with children as submenus.
+/// Shared by [FlowMenu]'s trigger menu and the message menu, so a host's
+/// one `entries` list reads the same wherever it is opened from.
+List<Widget> flowMenuEntryRows(
+  BuildContext context,
+  List<FlowMenuEntry> entries, {
+  FlowMenuStyle? style,
+  required ValueChanged<String> onSelected,
+}) {
+  FlowMenuRow optionRow(FlowMenuOption option) => FlowMenuRow(
+    label: option.label,
+    icon: option.icon,
+    selected: option.selected,
+    enabled: option.enabled,
+    style: style,
+    onTap: () => onSelected(option.id),
+  );
+  return [
+    for (final entry in entries)
+      switch (entry) {
+        FlowMenuDivider() => FlowMenuRule(style: style),
+        FlowMenuOption(children: []) => optionRow(entry),
+        FlowMenuOption() => FlowSubmenuRow(
+          style: style,
+          menuChildren: [
+            FlowMenuCard(
+              style: style,
+              children: [for (final child in entry.children) optionRow(child)],
+            ),
+          ],
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (entry.icon != null) ...[
+                Icon(
+                  entry.icon,
+                  size: 18,
+                  color: entry.enabled
+                      ? (style?.iconColor ??
+                            context.flowColors.onSurfaceVariant)
+                      : context.flowColors.onSurfaceDisabled,
+                ),
+                const SizedBox(width: flowMenuIconGap),
+              ],
+              Text(
+                entry.label,
+                style: flowMenuLabelStyle(context, large: false, style: style),
+              ),
+            ],
+          ),
+        ),
+      },
+  ];
+}
+
+/// Opens [entries] as the phone sheet, options with children pushing a
+/// page of their own.
+Future<void> showFlowMenuEntriesSheet({
+  required BuildContext context,
+  required List<FlowMenuEntry> entries,
+  FlowMenuStyle? style,
+  String? title,
+  required ValueChanged<String> onSelected,
+}) {
+  FlowMenuRow optionRow(FlowMenuOption option) => FlowMenuRow(
+    label: option.label,
+    icon: option.icon,
+    selected: option.selected,
+    enabled: option.enabled,
+    large: true,
+    style: style,
+    onTap: () => onSelected(option.id),
+  );
+  return showFlowMenuSheet(
+    context: context,
+    style: style,
+    root: FlowMenuSheetPage(
+      title: title,
+      children: (context) => [
+        for (final entry in entries)
+          switch (entry) {
+            FlowMenuDivider() => FlowMenuRule(style: style, large: true),
+            FlowMenuOption(children: []) => optionRow(entry),
+            FlowMenuOption() => FlowMenuRow(
+              label: entry.label,
+              icon: entry.icon,
+              enabled: entry.enabled,
+              showChevron: true,
+              large: true,
+              style: style,
+              closeOnTap: false,
+              onTap: () => FlowMenuSheetScope.maybeOf(context)?.push(
+                FlowMenuSheetPage(
+                  title: entry.label,
+                  children: (context) => [
+                    for (final child in entry.children) optionRow(child),
+                  ],
+                ),
+              ),
+            ),
+          },
+      ],
+    ),
+  );
+}

--- a/lib/src/utils/flow_selection_theme.dart
+++ b/lib/src/utils/flow_selection_theme.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart' show CupertinoTheme;
+import 'package:material_ui/material_ui.dart';
+
+import '../theme/flow_theme.dart';
+
+/// Text editing and selection in the Flow accent: the caret, the selection
+/// wash and the handles, plus the Cupertino primary that iOS draws its
+/// handles and toolbar with. Without this a host that installs [FlowTheme]
+/// on a stock `ThemeData` gets Material's default purple caret against
+/// Flow's primary — the one place the accent otherwise leaks through from
+/// the host's `ColorScheme`.
+class FlowSelectionTheme extends StatelessWidget {
+  const FlowSelectionTheme({super.key, required this.child});
+
+  final Widget child;
+
+  /// The selection wash: the accent at Material's own 40%.
+  static const double _selectionAlpha = 0.4;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = context.flowColors.primary;
+    return TextSelectionTheme(
+      data: TextSelectionThemeData(
+        cursorColor: primary,
+        selectionColor: primary.withValues(alpha: _selectionAlpha),
+        selectionHandleColor: primary,
+      ),
+      child: CupertinoTheme(
+        data: CupertinoTheme.of(context).copyWith(primaryColor: primary),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -25,6 +25,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     this.minWidth = 44,
     this.minHeight = 44,
     this.topShare = 0.5,
+    this.leftShare = 0.5,
     required Widget super.child,
   });
 
@@ -33,6 +34,11 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
 
   /// How much of the spare height sits above the child, 0–1.
   final double topShare;
+
+  /// How much of the spare width sits left of the child, 0–1: a strip's
+  /// first button keeps its frame at the strip's start, its last at the
+  /// end.
+  final double leftShare;
 
   /// Whether the theme's platform is one driven by touch.
   static bool isTouch(BuildContext context) {
@@ -47,6 +53,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
       minWidth: touch ? minWidth : 0,
       minHeight: touch ? minHeight : 0,
       topShare: topShare,
+      leftShare: leftShare,
     );
   }
 
@@ -59,7 +66,8 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     renderObject
       ..minWidth = touch ? minWidth : 0
       ..minHeight = touch ? minHeight : 0
-      ..topShare = topShare;
+      ..topShare = topShare
+      ..leftShare = leftShare;
   }
 }
 
@@ -70,6 +78,7 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     required this._minWidth,
     required this._minHeight,
     required this._topShare,
+    required this._leftShare,
     RenderBox? child,
   }) : super(child);
 
@@ -91,6 +100,13 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
   set topShare(double value) {
     if (value == _topShare) return;
     _topShare = value;
+    markNeedsLayout();
+  }
+
+  double _leftShare;
+  set leftShare(double value) {
+    if (value == _leftShare) return;
+    _leftShare = value;
     markNeedsLayout();
   }
 
@@ -130,7 +146,7 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     child.layout(constraints, parentUsesSize: true);
     size = constraints.constrain(_reserve(child.size));
     (child.parentData! as BoxParentData).offset = Offset(
-      (size.width - child.size.width) / 2,
+      (size.width - child.size.width) * _leftShare,
       (size.height - child.size.height) * _topShare,
     );
   }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -1,20 +1,21 @@
-import 'package:flutter/rendering.dart'
-    show BoxHitTestEntry, BoxHitTestResult, RenderProxyBox;
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
 import 'package:material_ui/material_ui.dart';
 
-/// Widens a small control's hit area on touch platforms without changing
-/// its layout. The design draws message actions on a 20px frame and the
-/// composer's glyph buttons on 24–32px discs; a finger needs 44 (Apple) to
-/// 48 (Material) and neither guideline is met by the frame alone. Material
-/// reserves that space in layout, which would open the rows up; this keeps
-/// the drawn size and accepts hits from the surrounding [minWidth] by
-/// [minHeight], [topShare] of the vertical extension above the child and
-/// the rest below.
+/// Reserves a finger's reach around a small control on touch platforms.
+/// The design draws message actions on a 20px frame and the composer's
+/// glyph buttons on 24–32px discs; a finger needs 44 (Apple) to 48
+/// (Material). Every ancestor rejects a pointer outside its own box before
+/// its children are asked, so the reach has to exist in layout: this lays
+/// out at least [minWidth] by [minHeight], seats the child with [topShare]
+/// of the spare height above it, and routes a hit anywhere in the box to
+/// the child's nearest edge — Material's own tap-target padding.
 ///
-/// Sized per site rather than a flat 44: a hit area that reaches into a
-/// neighbouring control steals its taps, since siblings are hit-tested in
-/// reverse order rather than by distance. A row of 20px actions on a 4px
-/// pitch keeps [minWidth] at 24 and takes its reach vertically.
+/// Sized per site rather than a flat 44, and absorbed from the gap beside
+/// the control where one exists — the message strip grows up into the
+/// footer gap, the composer's attach into the row inset — so the drawn
+/// frames stay where the design put them.
 ///
 /// A pointer platform passes straight through, by the theme's platform as
 /// the menus and the composer resolve it, so hosts and tests can steer it.
@@ -30,17 +31,18 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
   final double minWidth;
   final double minHeight;
 
-  /// How much of the vertical extension sits above the child, 0–1.
+  /// How much of the spare height sits above the child, 0–1.
   final double topShare;
 
-  static bool _touch(BuildContext context) {
+  /// Whether the theme's platform is one driven by touch.
+  static bool isTouch(BuildContext context) {
     final platform = Theme.of(context).platform;
     return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
   }
 
   @override
   RenderFlowTouchTarget createRenderObject(BuildContext context) {
-    final touch = _touch(context);
+    final touch = isTouch(context);
     return RenderFlowTouchTarget(
       minWidth: touch ? minWidth : 0,
       minHeight: touch ? minHeight : 0,
@@ -53,7 +55,7 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
     BuildContext context,
     RenderFlowTouchTarget renderObject,
   ) {
-    final touch = _touch(context);
+    final touch = isTouch(context);
     renderObject
       ..minWidth = touch ? minWidth : 0
       ..minHeight = touch ? minHeight : 0
@@ -61,41 +63,95 @@ class FlowTouchTarget extends SingleChildRenderObjectWidget {
   }
 }
 
-/// The render side of [FlowTouchTarget]: lays out as its child and accepts
-/// hits from the wider reach.
-class RenderFlowTouchTarget extends RenderProxyBox {
+/// The render side of [FlowTouchTarget]: the child's size grown to the
+/// minimums, the child seated inside, every hit in the box the child's.
+class RenderFlowTouchTarget extends RenderShiftedBox {
   RenderFlowTouchTarget({
-    required this.minWidth,
-    required this.minHeight,
-    required this.topShare,
-  });
+    required this._minWidth,
+    required this._minHeight,
+    required this._topShare,
+    RenderBox? child,
+  }) : super(child);
 
-  double minWidth;
-  double minHeight;
-  double topShare;
+  double _minWidth;
+  set minWidth(double value) {
+    if (value == _minWidth) return;
+    _minWidth = value;
+    markNeedsLayout();
+  }
+
+  double _minHeight;
+  set minHeight(double value) {
+    if (value == _minHeight) return;
+    _minHeight = value;
+    markNeedsLayout();
+  }
+
+  double _topShare;
+  set topShare(double value) {
+    if (value == _topShare) return;
+    _topShare = value;
+    markNeedsLayout();
+  }
+
+  Size _reserve(Size childSize) => Size(
+    math.max(childSize.width, _minWidth),
+    math.max(childSize.height, _minHeight),
+  );
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      math.max(child?.getMinIntrinsicWidth(height) ?? 0, _minWidth);
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      math.max(child?.getMaxIntrinsicWidth(height) ?? 0, _minWidth);
+
+  @override
+  double computeMinIntrinsicHeight(double width) =>
+      math.max(child?.getMinIntrinsicHeight(width) ?? 0, _minHeight);
+
+  @override
+  double computeMaxIntrinsicHeight(double width) =>
+      math.max(child?.getMaxIntrinsicHeight(width) ?? 0, _minHeight);
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) => constraints.constrain(
+    _reserve(child?.getDryLayout(constraints) ?? Size.zero),
+  );
+
+  @override
+  void performLayout() {
+    final child = this.child;
+    if (child == null) {
+      size = constraints.constrain(_reserve(Size.zero));
+      return;
+    }
+    child.layout(constraints, parentUsesSize: true);
+    size = constraints.constrain(_reserve(child.size));
+    (child.parentData! as BoxParentData).offset = Offset(
+      (size.width - child.size.width) / 2,
+      (size.height - child.size.height) * _topShare,
+    );
+  }
 
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    if (child == null) return false;
-    final extraX = (minWidth - size.width).clamp(0.0, double.infinity);
-    final extraY = (minHeight - size.height).clamp(0.0, double.infinity);
-    final reach = Rect.fromLTRB(
-      -extraX / 2,
-      -extraY * topShare,
-      size.width + extraX / 2,
-      size.height + extraY * (1 - topShare),
+    if (super.hitTest(result, position: position)) return true;
+    final child = this.child;
+    if (child == null || !size.contains(position)) return false;
+    // In the reach but off the child: the hit lands on the child's
+    // nearest edge, so its gesture and ink both accept it.
+    final offset = (child.parentData! as BoxParentData).offset;
+    final local = position - offset;
+    final nearest = Offset(
+      local.dx.clamp(0.0, child.size.width - 0.01),
+      local.dy.clamp(0.0, child.size.height - 0.01),
     );
-    if (!reach.contains(position)) return false;
-    // A hit outside the child's own bounds lands on its nearest edge, so
-    // the control's gesture and ink both accept it.
-    final inside = Offset(
-      position.dx.clamp(0.0, size.width - 0.01),
-      position.dy.clamp(0.0, size.height - 0.01),
+    return result.addWithRawTransform(
+      transform: MatrixUtils.forceToPoint(nearest),
+      position: nearest,
+      hitTest: (result, position) => child.hitTest(result, position: nearest),
     );
-    if (hitTestChildren(result, position: inside)) {
-      result.add(BoxHitTestEntry(this, position));
-      return true;
-    }
-    return false;
   }
 }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -10,7 +10,7 @@ import 'package:material_ui/material_ui.dart';
 /// its children are asked, so the reach has to exist in layout: this lays
 /// out at least [minWidth] by [minHeight], seats the child with [topShare]
 /// of the spare height above it, and routes a hit anywhere in the box to
-/// the child's nearest edge — Material's own tap-target padding.
+/// the child's centre — Material's own tap-target padding.
 ///
 /// Sized per site rather than a flat 44, and absorbed from the gap beside
 /// the control where one exists — the message strip grows up into the
@@ -156,18 +156,14 @@ class RenderFlowTouchTarget extends RenderShiftedBox {
     if (super.hitTest(result, position: position)) return true;
     final child = this.child;
     if (child == null || !size.contains(position)) return false;
-    // In the reach but off the child: the hit lands on the child's
-    // nearest edge, so its gesture and ink both accept it.
-    final offset = (child.parentData! as BoxParentData).offset;
-    final local = position - offset;
-    final nearest = Offset(
-      local.dx.clamp(0.0, child.size.width - 0.01),
-      local.dy.clamp(0.0, child.size.height - 0.01),
-    );
+    // In the reach but off the control: the hit lands on the child's
+    // centre, Material's own rule, so the control's gesture and ink take
+    // it whatever frame or ring sits around them.
+    final center = child.size.center(Offset.zero);
     return result.addWithRawTransform(
-      transform: MatrixUtils.forceToPoint(nearest),
-      position: nearest,
-      hitTest: (result, position) => child.hitTest(result, position: nearest),
+      transform: MatrixUtils.forceToPoint(center),
+      position: center,
+      hitTest: (result, position) => child.hitTest(result, position: center),
     );
   }
 }

--- a/lib/src/utils/flow_touch_target.dart
+++ b/lib/src/utils/flow_touch_target.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/rendering.dart'
+    show BoxHitTestEntry, BoxHitTestResult, RenderProxyBox;
+import 'package:material_ui/material_ui.dart';
+
+/// Widens a small control's hit area on touch platforms without changing
+/// its layout. The design draws message actions on a 20px frame and the
+/// composer's glyph buttons on 24–32px discs; a finger needs 44 (Apple) to
+/// 48 (Material) and neither guideline is met by the frame alone. Material
+/// reserves that space in layout, which would open the rows up; this keeps
+/// the drawn size and accepts hits from the surrounding [minWidth] by
+/// [minHeight], [topShare] of the vertical extension above the child and
+/// the rest below.
+///
+/// Sized per site rather than a flat 44: a hit area that reaches into a
+/// neighbouring control steals its taps, since siblings are hit-tested in
+/// reverse order rather than by distance. A row of 20px actions on a 4px
+/// pitch keeps [minWidth] at 24 and takes its reach vertically.
+///
+/// A pointer platform passes straight through, by the theme's platform as
+/// the menus and the composer resolve it, so hosts and tests can steer it.
+class FlowTouchTarget extends SingleChildRenderObjectWidget {
+  const FlowTouchTarget({
+    super.key,
+    this.minWidth = 44,
+    this.minHeight = 44,
+    this.topShare = 0.5,
+    required Widget super.child,
+  });
+
+  final double minWidth;
+  final double minHeight;
+
+  /// How much of the vertical extension sits above the child, 0–1.
+  final double topShare;
+
+  static bool _touch(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
+  }
+
+  @override
+  RenderFlowTouchTarget createRenderObject(BuildContext context) {
+    final touch = _touch(context);
+    return RenderFlowTouchTarget(
+      minWidth: touch ? minWidth : 0,
+      minHeight: touch ? minHeight : 0,
+      topShare: topShare,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderFlowTouchTarget renderObject,
+  ) {
+    final touch = _touch(context);
+    renderObject
+      ..minWidth = touch ? minWidth : 0
+      ..minHeight = touch ? minHeight : 0
+      ..topShare = topShare;
+  }
+}
+
+/// The render side of [FlowTouchTarget]: lays out as its child and accepts
+/// hits from the wider reach.
+class RenderFlowTouchTarget extends RenderProxyBox {
+  RenderFlowTouchTarget({
+    required this.minWidth,
+    required this.minHeight,
+    required this.topShare,
+  });
+
+  double minWidth;
+  double minHeight;
+  double topShare;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (child == null) return false;
+    final extraX = (minWidth - size.width).clamp(0.0, double.infinity);
+    final extraY = (minHeight - size.height).clamp(0.0, double.infinity);
+    final reach = Rect.fromLTRB(
+      -extraX / 2,
+      -extraY * topShare,
+      size.width + extraX / 2,
+      size.height + extraY * (1 - topShare),
+    );
+    if (!reach.contains(position)) return false;
+    // A hit outside the child's own bounds lands on its nearest edge, so
+    // the control's gesture and ink both accept it.
+    final inside = Offset(
+      position.dx.clamp(0.0, size.width - 0.01),
+      position.dy.clamp(0.0, size.height - 0.01),
+    );
+    if (hitTestChildren(result, position: inside)) {
+      result.add(BoxHitTestEntry(this, position));
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/src/widgets/flow_chat_view.dart
+++ b/lib/src/widgets/flow_chat_view.dart
@@ -9,6 +9,7 @@ import '../models/flow_attachment_options.dart';
 import '../styles/flow_chat_view_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
 import 'flow_drop_target.dart';
 import 'flow_thread.dart';
 
@@ -371,13 +372,17 @@ class _FlowChatViewState extends State<FlowChatView> {
     // Outside the SafeArea, so the drop rectangle is the whole surface —
     // the treatment is full-bleed and the target should match it. A plain
     // pass-through off the web, where it registers nothing.
-    return FlowDropTarget(
-      onDropped: widget.onAttachmentsDropped,
-      enabled: widget.attachmentsEnabled,
-      onHoverChanged: _handleDropHover,
-      attachmentOptions: widget.attachmentOptions,
-      onAttachmentRejected: widget.onAttachmentRejected,
-      child: _buildSurface(context, safeBottom),
+    // Editing and selection in the Flow accent for everything on the
+    // surface — the composer's caret, a selected code block's wash.
+    return FlowSelectionTheme(
+      child: FlowDropTarget(
+        onDropped: widget.onAttachmentsDropped,
+        enabled: widget.attachmentsEnabled,
+        onHoverChanged: _handleDropHover,
+        attachmentOptions: widget.attachmentOptions,
+        onAttachmentRejected: widget.onAttachmentRejected,
+        child: _buildSurface(context, safeBottom),
+      ),
     );
   }
 

--- a/lib/src/widgets/flow_code_block.dart
+++ b/lib/src/widgets/flow_code_block.dart
@@ -4,6 +4,7 @@ import '../styles/flow_code_block_style.dart';
 import '../theme/flow_syntax_colors.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_syntax_highlighter.dart';
+import '../utils/flow_touch_target.dart';
 
 export '../utils/flow_syntax_highlighter.dart'
     show FlowCodeLanguage, FlowSyntaxRule, FlowSyntaxToken;
@@ -383,6 +384,6 @@ class _CopyButtonState extends State<_CopyButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 }

--- a/lib/src/widgets/flow_code_block.dart
+++ b/lib/src/widgets/flow_code_block.dart
@@ -107,6 +107,16 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
     vertical: 12,
   );
   static const double _headerHeight = 36;
+
+  /// On touch platforms the copy affordance takes the header's height as
+  /// its reach, 6 a side in width; the header's inset gives up those 6 so
+  /// the glyph draws where it did, and the label keeps its 10 from the top
+  /// on its own.
+  static const EdgeInsetsGeometry _headerPaddingTouch = EdgeInsets.only(
+    left: 16,
+    right: 6,
+  );
+  static const double _labelTop = 10;
   static const EdgeInsetsGeometry _headerPadding = EdgeInsets.only(
     left: 16,
     right: 12,
@@ -217,6 +227,7 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
     final hasHeader = label != null || widget.onCopy != null;
 
     final padding = widget.padding ?? _bodyPadding;
+    final touch = FlowTouchTarget.isTouch(context);
     final code = SelectableText.rich(span);
     final body = widget.wrap
         ? Padding(padding: padding, child: code)
@@ -256,19 +267,27 @@ class _FlowCodeBlockState extends State<FlowCodeBlock> {
             if (hasHeader)
               Container(
                 height: _headerHeight,
-                padding: _headerPadding,
+                padding: touch ? _headerPaddingTouch : _headerPadding,
                 child: Row(
+                  crossAxisAlignment: touch
+                      ? CrossAxisAlignment.start
+                      : CrossAxisAlignment.center,
                   children: [
                     Expanded(
                       child: label == null
                           ? const SizedBox.shrink()
-                          : Text(
-                              label,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: typography.labelMedium
-                                  .copyWith(color: colors.onSurfaceMuted)
-                                  .merge(style?.headerStyle),
+                          : Padding(
+                              padding: EdgeInsets.only(
+                                top: touch ? _labelTop : 0,
+                              ),
+                              child: Text(
+                                label,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: typography.labelMedium
+                                    .copyWith(color: colors.onSurfaceMuted)
+                                    .merge(style?.headerStyle),
+                              ),
                             ),
                     ),
                     if (showCopy)
@@ -344,6 +363,11 @@ class _CopyButtonState extends State<_CopyButton> {
   /// menu rows keep to their card.
   static const BorderRadius _frameRadius = BorderRadius.all(Radius.circular(6));
 
+  /// The header's height as the reach on touch platforms, the frame seated
+  /// where the header's 10 top inset and centring put it.
+  static const double _touch = 36;
+  static const double _touchTopShare = 11 / 12;
+
   bool _hovered = false;
 
   @override
@@ -384,6 +408,11 @@ class _CopyButtonState extends State<_CopyButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return FlowTouchTarget(child: button);
+    return FlowTouchTarget(
+      minWidth: _touch,
+      minHeight: _touch,
+      topShare: _touchTopShare,
+      child: button,
+    );
   }
 }

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -10,6 +10,8 @@ import '../styles/flow_composer_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_attachment_intake.dart';
 import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
+import '../utils/flow_touch_target.dart';
 import '../utils/flow_clipboard_paste.dart';
 import '../utils/flow_file_picker.dart';
 import '../utils/flow_gradient_outline.dart';
@@ -99,6 +101,8 @@ class FlowComposer extends StatefulWidget {
     this.onAttachmentTap,
     this.removeAttachmentTooltip,
     this.previewCloseTooltip,
+    this.sendTooltip,
+    this.stopTooltip,
     this.onAttach,
     this.onAttachmentsPicked,
     this.onAttachmentsDropped,
@@ -275,6 +279,14 @@ class FlowComposer extends StatefulWidget {
   /// Host-localized label for the attach button; also its accessible
   /// name.
   final String? attachTooltip;
+
+  /// Host-localized label for the send disc; also its accessible name.
+  /// Without one assistive tech announces an unnamed button.
+  final String? sendTooltip;
+
+  /// Host-localized label for the stop disc while streaming; also its
+  /// accessible name.
+  final String? stopTooltip;
 
   /// Raises the error banner: the design's tab above the card, in the
   /// error wash with a warning glyph and this line. Null draws nothing.
@@ -670,7 +682,7 @@ class _FlowComposerState extends State<FlowComposer> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    return FlowTouchTarget(child: button);
   }
 
   Widget _buildSendStopButton(BuildContext context) {
@@ -687,6 +699,7 @@ class _FlowComposerState extends State<FlowComposer> {
           background: discColor,
           foreground: glyphColor,
           padding: _stopPadding,
+          tooltip: widget.stopTooltip,
           onTap: widget.onStop,
         ),
       );
@@ -695,26 +708,29 @@ class _FlowComposerState extends State<FlowComposer> {
       valueListenable: _controller,
       builder: (context, value, _) {
         final canSend = _canSend(value.text.trim());
-        return _ringed(
-          context,
-          active: canSend,
-          disc: Material(
-            // Disabled keeps the arrow's ink and only drains the disc:
-            // primary gives way to the 30% disabled wash.
-            color: canSend ? discColor : colors.onSurfaceDisabled,
-            shape: const CircleBorder(),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: canSend ? _send : null,
-              customBorder: const CircleBorder(),
-              child: CustomPaint(
-                // The design's arrow is a thin stroke, not the chunky
-                // Material glyph.
-                painter: _ArrowUpPainter(color: glyphColor),
-              ),
+        final sendTooltip = widget.sendTooltip;
+        Widget disc = Material(
+          // Disabled keeps the arrow's ink and only drains the disc:
+          // primary gives way to the 30% disabled wash.
+          color: canSend ? discColor : colors.onSurfaceDisabled,
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: canSend ? _send : null,
+            customBorder: const CircleBorder(),
+            child: CustomPaint(
+              // The design's arrow is a thin stroke, not the chunky
+              // Material glyph.
+              painter: _ArrowUpPainter(color: glyphColor),
             ),
           ),
         );
+        // Tooltip contributes the accessible name too, per the attach
+        // button's precedent.
+        if (sendTooltip != null) {
+          disc = Tooltip(message: sendTooltip, child: disc);
+        }
+        return _ringed(context, active: canSend, disc: disc);
       },
     );
   }
@@ -813,22 +829,24 @@ class _FlowComposerState extends State<FlowComposer> {
     // The banner sits above the card and outside the drop target: it is
     // not somewhere to drop a file. AnimatedSize grows it in from the
     // card's top edge, so the thread above eases up rather than jumping.
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        AnimatedSize(
-          duration: MediaQuery.disableAnimationsOf(context)
-              ? Duration.zero
-              : _errorReveal,
-          curve: Curves.easeOut,
-          alignment: Alignment.bottomCenter,
-          child: errorMessage == null
-              ? const SizedBox.shrink()
-              : _buildErrorBanner(context, errorMessage),
-        ),
-        _buildCard(context),
-      ],
+    return FlowSelectionTheme(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          AnimatedSize(
+            duration: MediaQuery.disableAnimationsOf(context)
+                ? Duration.zero
+                : _errorReveal,
+            curve: Curves.easeOut,
+            alignment: Alignment.bottomCenter,
+            child: errorMessage == null
+                ? const SizedBox.shrink()
+                : _buildErrorBanner(context, errorMessage),
+          ),
+          _buildCard(context),
+        ],
+      ),
     );
   }
 

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -625,6 +625,7 @@ class _FlowComposerState extends State<FlowComposer> {
     BuildContext context, {
     required bool active,
     required Widget disc,
+    required VoidCallback? onTap,
   }) {
     final colors = context.flowColors;
     final style = _styleOf(context);
@@ -632,21 +633,27 @@ class _FlowComposerState extends State<FlowComposer> {
     return FlowTouchTarget(
       minWidth: _buttonFrame,
       minHeight: _rowTouch,
-      child: Container(
-        width: _buttonFrame,
-        height: _buttonFrame,
-        alignment: Alignment.center,
-        decoration: ShapeDecoration(
-          color: style?.backgroundColor ?? colors.surfaceBright,
-          shape: CircleBorder(
-            side: BorderSide(
-              color: active
-                  ? (style?.sendBackgroundColor ?? colors.primary)
-                  : colors.outlineVariant,
+      child: GestureDetector(
+        // The ring around the disc is the button too: a tap on it, or
+        // one the reach lands on the frame, fires without the ink.
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: _buttonFrame,
+          height: _buttonFrame,
+          alignment: Alignment.center,
+          decoration: ShapeDecoration(
+            color: style?.backgroundColor ?? colors.surfaceBright,
+            shape: CircleBorder(
+              side: BorderSide(
+                color: active
+                    ? (style?.sendBackgroundColor ?? colors.primary)
+                    : colors.outlineVariant,
+              ),
             ),
           ),
+          child: SizedBox.square(dimension: _buttonDisc, child: disc),
         ),
-        child: SizedBox.square(dimension: _buttonDisc, child: disc),
       ),
     );
   }
@@ -715,6 +722,7 @@ class _FlowComposerState extends State<FlowComposer> {
       return _ringed(
         context,
         active: true,
+        onTap: widget.onStop,
         disc: FlowCircleButton(
           icon: Icons.stop_rounded,
           background: discColor,
@@ -751,7 +759,12 @@ class _FlowComposerState extends State<FlowComposer> {
         if (sendTooltip != null) {
           disc = Tooltip(message: sendTooltip, child: disc);
         }
-        return _ringed(context, active: canSend, disc: disc);
+        return _ringed(
+          context,
+          active: canSend,
+          onTap: canSend ? _send : null,
+          disc: disc,
+        );
       },
     );
   }

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -635,8 +635,11 @@ class _FlowComposerState extends State<FlowComposer> {
       minHeight: _rowTouch,
       child: GestureDetector(
         // The ring around the disc is the button too: a tap on it, or
-        // one the reach lands on the frame, fires without the ink.
+        // one the reach lands on the frame, fires without the ink. Out of
+        // the semantics tree: the disc's own button node carries the
+        // name, and a second tap node beside it would announce unnamed.
         behavior: HitTestBehavior.opaque,
+        excludeFromSemantics: true,
         onTap: onTap,
         child: Container(
           width: _buttonFrame,

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -361,11 +361,14 @@ class _FlowComposerState extends State<FlowComposer> {
   static const double _contentInset = 18;
   static const double _actionInset = 10;
 
-  /// The attach glyph's reach on touch platforms: the row's own 40, the
-  /// send disc's height, so it costs no height, and 4 a side in width,
-  /// taken from the row inset so the glyph draws where it did.
-  static const double _attachTouch = 40;
-  static const double _attachTouchSlack = 4;
+  /// The action row's reach on touch platforms: the attach glyph and the
+  /// send disc stay their drawn 32 wide and take 40 tall, the row growing
+  /// 4 each way into the field gap above and the card's bottom padding
+  /// below, so the card keeps its height and nothing moves.
+  static const double _rowTouch = 40;
+  static const double _rowTouchGrowth = (_rowTouch - _buttonFrame) / 2;
+  static const EdgeInsetsGeometry _cardPaddingTouch =
+      EdgeInsetsDirectional.fromSTEB(1, 19, 1, 11 - _rowTouchGrowth);
 
   /// The error tab's cross takes the tab's 30 on touch platforms.
   static const double _errorDismissTouch = 30;
@@ -625,21 +628,26 @@ class _FlowComposerState extends State<FlowComposer> {
   }) {
     final colors = context.flowColors;
     final style = _styleOf(context);
-    return Container(
-      width: _buttonFrame,
-      height: _buttonFrame,
-      alignment: Alignment.center,
-      decoration: ShapeDecoration(
-        color: style?.backgroundColor ?? colors.surfaceBright,
-        shape: CircleBorder(
-          side: BorderSide(
-            color: active
-                ? (style?.sendBackgroundColor ?? colors.primary)
-                : colors.outlineVariant,
+    // The disc keeps its 32 frame and takes the row's 40 on touch.
+    return FlowTouchTarget(
+      minWidth: _buttonFrame,
+      minHeight: _rowTouch,
+      child: Container(
+        width: _buttonFrame,
+        height: _buttonFrame,
+        alignment: Alignment.center,
+        decoration: ShapeDecoration(
+          color: style?.backgroundColor ?? colors.surfaceBright,
+          shape: CircleBorder(
+            side: BorderSide(
+              color: active
+                  ? (style?.sendBackgroundColor ?? colors.primary)
+                  : colors.outlineVariant,
+            ),
           ),
         ),
+        child: SizedBox.square(dimension: _buttonDisc, child: disc),
       ),
-      child: SizedBox.square(dimension: _buttonDisc, child: disc),
     );
   }
 
@@ -692,8 +700,8 @@ class _FlowComposerState extends State<FlowComposer> {
       button = Tooltip(message: tooltip, child: button);
     }
     return FlowTouchTarget(
-      minWidth: _attachTouch,
-      minHeight: _attachTouch,
+      minWidth: _buttonFrame,
+      minHeight: _rowTouch,
       child: button,
     );
   }
@@ -758,7 +766,11 @@ class _FlowComposerState extends State<FlowComposer> {
     final foreground = style?.errorForegroundColor ?? colors.onErrorContainer;
     final icon = widget.errorIcon;
     final onDismiss = widget.onErrorDismiss;
-    const dismissDisc = _errorDismissIconSize + _errorDismissPadding * 2;
+    // On touch the cross reaches the tab's 30, which the padding then
+    // gives up entirely, so the tab keeps its height either way.
+    final dismissDisc = FlowTouchTarget.isTouch(context)
+        ? _errorDismissTouch
+        : _errorDismissIconSize + _errorDismissPadding * 2;
     final verticalPadding = onDismiss == null
         ? _errorVerticalPadding
         : _errorVerticalPadding - (dismissDisc - _errorIconSize) / 2;
@@ -869,6 +881,7 @@ class _FlowComposerState extends State<FlowComposer> {
   Widget _buildCard(BuildContext context) {
     final colors = context.flowColors;
     final typography = context.flowTypography;
+    final touch = FlowTouchTarget.isTouch(context);
 
     final active = widget.enabled && (_focused || _hovered);
     final radius = widget.borderRadius ?? _cardRadius;
@@ -964,7 +977,9 @@ class _FlowComposerState extends State<FlowComposer> {
                     BoxShadow(color: colors.shadow, blurRadius: _shadowBlur),
                   ],
                 ),
-                padding: widget.padding ?? _cardPadding,
+                padding:
+                    widget.padding ??
+                    (touch ? _cardPaddingTouch : _cardPadding),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1040,12 +1055,12 @@ class _FlowComposerState extends State<FlowComposer> {
                         ),
                       ),
                     ),
-                    const SizedBox(height: _fieldGap),
+                    SizedBox(
+                      height: touch ? _fieldGap - _rowTouchGrowth : _fieldGap,
+                    ),
                     Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: FlowTouchTarget.isTouch(context)
-                            ? _actionInset - _attachTouchSlack
-                            : _actionInset,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: _actionInset,
                       ),
                       child: Row(
                         children: [

--- a/lib/src/widgets/flow_composer.dart
+++ b/lib/src/widgets/flow_composer.dart
@@ -360,6 +360,15 @@ class _FlowComposerState extends State<FlowComposer> {
   );
   static const double _contentInset = 18;
   static const double _actionInset = 10;
+
+  /// The attach glyph's reach on touch platforms: the row's own 40, the
+  /// send disc's height, so it costs no height, and 4 a side in width,
+  /// taken from the row inset so the glyph draws where it did.
+  static const double _attachTouch = 40;
+  static const double _attachTouchSlack = 4;
+
+  /// The error tab's cross takes the tab's 30 on touch platforms.
+  static const double _errorDismissTouch = 30;
   static const double _attachmentGap = 12;
   static const double _fieldGap = 16;
   static const double _leadingGap = 4;
@@ -682,7 +691,11 @@ class _FlowComposerState extends State<FlowComposer> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return FlowTouchTarget(child: button);
+    return FlowTouchTarget(
+      minWidth: _attachTouch,
+      minHeight: _attachTouch,
+      child: button,
+    );
   }
 
   Widget _buildSendStopButton(BuildContext context) {
@@ -812,6 +825,7 @@ class _FlowComposerState extends State<FlowComposer> {
                       hoverColor: background,
                       iconSize: _errorDismissIconSize,
                       padding: _errorDismissPadding,
+                      touchMinSize: _errorDismissTouch,
                       tooltip: widget.errorDismissTooltip,
                       onTap: onDismiss,
                     ),
@@ -1028,8 +1042,10 @@ class _FlowComposerState extends State<FlowComposer> {
                     ),
                     const SizedBox(height: _fieldGap),
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: _actionInset,
+                      padding: EdgeInsets.symmetric(
+                        horizontal: FlowTouchTarget.isTouch(context)
+                            ? _actionInset - _attachTouchSlack
+                            : _actionInset,
                       ),
                       child: Row(
                         children: [

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -4,6 +4,7 @@ import '../styles/flow_menu_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_menu_core.dart';
 import '../utils/flow_menu_sheet.dart';
+import '../utils/flow_touch_target.dart';
 
 /// One entry in a [FlowMenu]: an option or a divider.
 @immutable
@@ -278,7 +279,7 @@ class _FlowMenuState extends State<FlowMenu> {
         if (tooltip != null) {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
-        return trigger;
+        return FlowTouchTarget(child: trigger);
       },
     );
   }

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -3,7 +3,7 @@ import 'package:material_ui/material_ui.dart';
 import '../styles/flow_menu_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_menu_core.dart';
-import '../utils/flow_menu_sheet.dart';
+import '../utils/flow_menu_entries.dart';
 import '../utils/flow_touch_target.dart';
 
 /// One entry in a [FlowMenu]: an option or a divider.
@@ -137,101 +137,21 @@ class _FlowMenuState extends State<FlowMenu> {
 
   bool get _hasOptions => widget.entries.whereType<FlowMenuOption>().isNotEmpty;
 
-  FlowMenuRow _optionRow(FlowMenuOption option, {required bool large}) {
-    return FlowMenuRow(
-      label: option.label,
-      icon: option.icon,
-      selected: option.selected,
-      enabled: option.enabled,
-      large: large,
-      style: _style,
-      onTap: () => widget.onSelected?.call(option.id),
-    );
-  }
-
   /// The anchored menu's children.
-  List<Widget> _menuChildren(BuildContext context) {
-    final style = _style;
-    return [
-      for (final entry in widget.entries)
-        switch (entry) {
-          FlowMenuDivider() => FlowMenuRule(style: style),
-          FlowMenuOption(children: []) => _optionRow(entry, large: false),
-          FlowMenuOption() => FlowSubmenuRow(
-            style: style,
-            menuChildren: [
-              FlowMenuCard(
-                style: style,
-                children: [
-                  for (final child in entry.children)
-                    _optionRow(child, large: false),
-                ],
-              ),
-            ],
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (entry.icon != null) ...[
-                  Icon(
-                    entry.icon,
-                    size: 18,
-                    color: entry.enabled
-                        ? (style?.iconColor ??
-                              context.flowColors.onSurfaceVariant)
-                        : context.flowColors.onSurfaceDisabled,
-                  ),
-                  const SizedBox(width: flowMenuIconGap),
-                ],
-                Text(
-                  entry.label,
-                  style: flowMenuLabelStyle(
-                    context,
-                    large: false,
-                    style: style,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        },
-    ];
-  }
+  List<Widget> _menuChildren(BuildContext context) => flowMenuEntryRows(
+    context,
+    widget.entries,
+    style: _style,
+    onSelected: (id) => widget.onSelected?.call(id),
+  );
 
-  void _openSheet() {
-    final style = _style;
-    showFlowMenuSheet(
-      context: context,
-      style: style,
-      root: FlowMenuSheetPage(
-        title: widget.sheetTitle,
-        children: (context) => [
-          for (final entry in widget.entries)
-            switch (entry) {
-              FlowMenuDivider() => FlowMenuRule(style: style, large: true),
-              FlowMenuOption(children: []) => _optionRow(entry, large: true),
-              FlowMenuOption() => FlowMenuRow(
-                label: entry.label,
-                icon: entry.icon,
-                enabled: entry.enabled,
-                showChevron: true,
-                large: true,
-                style: style,
-                closeOnTap: false,
-                onTap: () => FlowMenuSheetScope.maybeOf(context)?.push(
-                  FlowMenuSheetPage(
-                    title: entry.label,
-                    children: (context) => [
-                      for (final child in entry.children)
-                        _optionRow(child, large: true),
-                    ],
-                  ),
-                ),
-              ),
-            },
-        ],
-      ),
-    );
-  }
+  void _openSheet() => showFlowMenuEntriesSheet(
+    context: context,
+    entries: widget.entries,
+    style: _style,
+    title: widget.sheetTitle,
+    onSelected: (id) => widget.onSelected?.call(id),
+  );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -129,6 +129,9 @@ class _FlowMenuState extends State<FlowMenu> {
   static const double _triggerIconSize = 18;
   static const double _triggerPadding = 7;
 
+  /// The trigger's reach on touch platforms: the composer row's 40.
+  static const double _triggerTouch = 40;
+
   bool _hovered = false;
 
   bool get _hasOptions => widget.entries.whereType<FlowMenuOption>().isNotEmpty;
@@ -279,7 +282,11 @@ class _FlowMenuState extends State<FlowMenu> {
         if (tooltip != null) {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
-        return FlowTouchTarget(child: trigger);
+        return FlowTouchTarget(
+          minWidth: _triggerTouch,
+          minHeight: _triggerTouch,
+          child: trigger,
+        );
       },
     );
   }

--- a/lib/src/widgets/flow_menu.dart
+++ b/lib/src/widgets/flow_menu.dart
@@ -129,8 +129,9 @@ class _FlowMenuState extends State<FlowMenu> {
   static const double _triggerIconSize = 18;
   static const double _triggerPadding = 7;
 
-  /// The trigger's reach on touch platforms: the composer row's 40.
-  static const double _triggerTouch = 40;
+  /// The trigger's reach on touch platforms: its drawn 32 wide, the
+  /// composer row's 40 tall, so a rail of triggers never shifts.
+  static const double _triggerTouchHeight = 40;
 
   bool _hovered = false;
 
@@ -283,8 +284,8 @@ class _FlowMenuState extends State<FlowMenu> {
           trigger = Tooltip(message: tooltip, child: trigger);
         }
         return FlowTouchTarget(
-          minWidth: _triggerTouch,
-          minHeight: _triggerTouch,
+          minWidth: _triggerIconSize + _triggerPadding * 2,
+          minHeight: _triggerTouchHeight,
           child: trigger,
         );
       },

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
@@ -195,14 +197,22 @@ class FlowMessage extends StatelessWidget {
 
   bool get _isError => message.status == FlowMessageStatus.error;
 
-  /// The gap above the footer, less the reach a [FlowMessageActions] strip
-  /// takes above its frames on touch platforms: the strip grows up into
-  /// the gap and the frames draw where the design put them.
-  double _footerGap(BuildContext context, double gap) {
+  /// The footer under its gap. A [FlowMessageActions] strip on touch
+  /// platforms reaches up into the gap instead: the strip grows by what
+  /// the gap holds, the gap shrinks by the same, and the frames draw where
+  /// the design put them.
+  Widget _footer(BuildContext context, Widget footer, double gap) {
     if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
-      return gap;
+      return Padding(
+        padding: EdgeInsets.only(top: gap),
+        child: footer,
+      );
     }
-    return (gap - FlowMessageActions.touchReach).clamp(0.0, gap);
+    final reach = math.min(gap, FlowMessageActions.touchReach);
+    return Padding(
+      padding: EdgeInsets.only(top: gap - reach),
+      child: FlowFooterReach(reach: reach, child: footer),
+    );
   }
 
   @override
@@ -272,13 +282,7 @@ class FlowMessage extends StatelessWidget {
                 constraints: BoxConstraints(maxWidth: maxWidth),
                 child: bubble,
               ),
-            if (footer != null)
-              Padding(
-                padding: EdgeInsets.only(
-                  top: _footerGap(context, _userFooterGap),
-                ),
-                child: footer,
-              ),
+            if (footer != null) _footer(context, footer!, _userFooterGap),
           ],
         );
       },
@@ -331,13 +335,7 @@ class FlowMessage extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         content,
-        if (footer != null)
-          Padding(
-            padding: EdgeInsets.only(
-              top: _footerGap(context, _assistantFooterGap),
-            ),
-            child: footer,
-          ),
+        if (footer != null) _footer(context, footer!, _assistantFooterGap),
       ],
     );
 

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -224,7 +224,10 @@ class FlowMessage extends StatelessWidget {
   /// the design put them.
   Widget _footer(BuildContext context, Widget footer, double gap) {
     if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
-      return Padding(padding: EdgeInsets.only(top: gap), child: footer);
+      return Padding(
+        padding: EdgeInsets.only(top: gap),
+        child: footer,
+      );
     }
     final reach = math.min(gap, FlowMessageActions.touchReach);
     return Padding(

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -7,11 +7,13 @@ import '../styles/flow_message_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_attachment_error.dart';
 import '../utils/flow_shimmer_sweep.dart';
+import '../utils/flow_touch_target.dart';
 import 'flow_attachment_group.dart';
 import 'flow_attachment_preview.dart';
 import 'flow_code_block.dart';
 import 'flow_error_state.dart';
 import 'flow_markdown.dart';
+import 'flow_message_actions.dart';
 import 'flow_streaming_text.dart';
 import 'flow_thinking_indicator.dart';
 
@@ -193,6 +195,16 @@ class FlowMessage extends StatelessWidget {
 
   bool get _isError => message.status == FlowMessageStatus.error;
 
+  /// The gap above the footer, less the reach a [FlowMessageActions] strip
+  /// takes above its frames on touch platforms: the strip grows up into
+  /// the gap and the frames draw where the design put them.
+  double _footerGap(BuildContext context, double gap) {
+    if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
+      return gap;
+    }
+    return (gap - FlowMessageActions.touchReach).clamp(0.0, gap);
+  }
+
   @override
   Widget build(BuildContext context) {
     return switch (message.role) {
@@ -262,7 +274,9 @@ class FlowMessage extends StatelessWidget {
               ),
             if (footer != null)
               Padding(
-                padding: const EdgeInsets.only(top: _userFooterGap),
+                padding: EdgeInsets.only(
+                  top: _footerGap(context, _userFooterGap),
+                ),
                 child: footer,
               ),
           ],
@@ -319,7 +333,9 @@ class FlowMessage extends StatelessWidget {
         content,
         if (footer != null)
           Padding(
-            padding: const EdgeInsets.only(top: _assistantFooterGap),
+            padding: EdgeInsets.only(
+              top: _footerGap(context, _assistantFooterGap),
+            ),
             child: footer,
           ),
       ],

--- a/lib/src/widgets/flow_message.dart
+++ b/lib/src/widgets/flow_message.dart
@@ -1,13 +1,17 @@
 import 'dart:math' as math;
 
+import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_attachment.dart';
 import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';
+import '../styles/flow_menu_style.dart' show FlowMenuPresentation;
 import '../styles/flow_message_style.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_attachment_error.dart';
+import '../utils/flow_menu_core.dart';
+import '../utils/flow_menu_entries.dart';
 import '../utils/flow_shimmer_sweep.dart';
 import '../utils/flow_touch_target.dart';
 import 'flow_attachment_group.dart';
@@ -16,6 +20,7 @@ import 'flow_code_block.dart';
 import 'flow_error_state.dart';
 import 'flow_markdown.dart';
 import 'flow_message_actions.dart';
+import 'flow_menu.dart' show FlowMenuEntry, FlowMenuOption;
 import 'flow_streaming_text.dart';
 import 'flow_thinking_indicator.dart';
 
@@ -59,6 +64,8 @@ class FlowMessage extends StatelessWidget {
     this.retryLabel,
     this.leading,
     this.footer,
+    this.menuEntries,
+    this.onMenuSelected,
     this.maxBubbleWidthFraction = 0.75,
     this.textStyle,
     this.charactersPerSecond = 300,
@@ -128,6 +135,20 @@ class FlowMessage extends StatelessWidget {
 
   /// Slot below the content, e.g. message actions.
   final Widget? footer;
+
+  /// The message's context menu — the AI apps' long-press: copy, edit,
+  /// regenerate, feedback, whatever the host offers. Options and dividers
+  /// like [FlowMenu.entries], labels the host's. Opens on a long-press
+  /// with a haptic on touch, and on a right-click on pointer platforms; a
+  /// sheet on phones, a popover at the pointer elsewhere, by the theme's
+  /// platform like the menus. Null or empty draws no menu.
+  ///
+  /// Long-presses inside a selectable region — a code block — keep
+  /// selecting; the menu takes the rest of the message.
+  final List<FlowMenuEntry>? menuEntries;
+
+  /// The chosen option's id. Null draws no menu.
+  final ValueChanged<String>? onMenuSelected;
 
   /// User-bubble max width as a fraction of the available width.
   final double maxBubbleWidthFraction;
@@ -203,10 +224,7 @@ class FlowMessage extends StatelessWidget {
   /// the design put them.
   Widget _footer(BuildContext context, Widget footer, double gap) {
     if (footer is! FlowMessageActions || !FlowTouchTarget.isTouch(context)) {
-      return Padding(
-        padding: EdgeInsets.only(top: gap),
-        child: footer,
-      );
+      return Padding(padding: EdgeInsets.only(top: gap), child: footer);
     }
     final reach = math.min(gap, FlowMessageActions.touchReach);
     return Padding(
@@ -217,11 +235,16 @@ class FlowMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return switch (message.role) {
+    final built = switch (message.role) {
       FlowMessageRole.user => _buildUser(context),
       FlowMessageRole.assistant => _buildAssistant(context),
       FlowMessageRole.system => _buildSystem(context),
     };
+    final entries = menuEntries;
+    final onMenu = onMenuSelected;
+    if (entries == null || onMenu == null) return built;
+    if (!entries.any((entry) => entry is FlowMenuOption)) return built;
+    return _MessageMenu(entries: entries, onSelected: onMenu, child: built);
   }
 
   Widget _buildUser(BuildContext context) {
@@ -718,6 +741,73 @@ class _SentImageTileState extends State<_SentImageTile> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// The message's context menu: a long-press or right-click anywhere on
+/// the message's own content opens the host's entries, as the phone sheet
+/// or a popover anchored where the pointer is. Defers to its child for
+/// hit-testing so the blank run beside a user bubble is not the message.
+class _MessageMenu extends StatefulWidget {
+  const _MessageMenu({
+    required this.entries,
+    required this.onSelected,
+    required this.child,
+  });
+
+  final List<FlowMenuEntry> entries;
+  final ValueChanged<String> onSelected;
+  final Widget child;
+
+  @override
+  State<_MessageMenu> createState() => _MessageMenuState();
+}
+
+class _MessageMenuState extends State<_MessageMenu> {
+  final MenuController _controller = MenuController();
+
+  void _open(Offset position, {required bool haptic}) {
+    final style = context.flowTheme.menuStyle;
+    if (flowMenuPresentsAsSheet(context, FlowMenuPresentation.auto)) {
+      // The touch confirmation the platforms' own long-presses give.
+      if (haptic) HapticFeedback.mediumImpact();
+      showFlowMenuEntriesSheet(
+        context: context,
+        entries: widget.entries,
+        style: style,
+        onSelected: widget.onSelected,
+      );
+      return;
+    }
+    _controller.open(position: position);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = context.flowTheme.menuStyle;
+    return MenuAnchor(
+      controller: _controller,
+      style: flowMenuStyle(context, style: style),
+      menuChildren: [
+        FlowMenuCard(
+          style: style,
+          children: flowMenuEntryRows(
+            context,
+            widget.entries,
+            style: style,
+            onSelected: widget.onSelected,
+          ),
+        ),
+      ],
+      child: GestureDetector(
+        behavior: HitTestBehavior.deferToChild,
+        onLongPressStart: (details) =>
+            _open(details.localPosition, haptic: true),
+        onSecondaryTapUp: (details) =>
+            _open(details.localPosition, haptic: false),
+        child: widget.child,
       ),
     );
   }

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -132,7 +132,16 @@ class FlowMessageActions extends StatelessWidget {
           (i == 0 || i == last ? _gap / 2 : _gap);
     }
 
-    double leftShare(int i) => i == 0 ? 0 : (i == last ? 1 : 0.5);
+    // Shares are physical, and a Row mirrors under RTL: the first action
+    // keeps its frame at the strip's start and the last at its end,
+    // whichever side those are.
+    final ltr = Directionality.of(context) == TextDirection.ltr;
+    double leftShare(int i) {
+      if (i == 0) return ltr ? 0 : 1;
+      if (i == last) return ltr ? 1 : 0;
+      return 0.5;
+    }
+
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -2,6 +2,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../styles/flow_message_actions_style.dart';
 import '../theme/flow_theme.dart';
+import '../utils/flow_touch_target.dart';
 
 /// One action in a [FlowMessageActions] row.
 ///
@@ -202,6 +203,14 @@ class _ActionButtonState extends State<_ActionButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    return button;
+    // The row keeps the design's 20px frames on a 4px pitch; a finger
+    // gets the pitch sideways and the design's 44 vertically, mostly
+    // downward into the gap between turns, off the text above.
+    return FlowTouchTarget(
+      minWidth: _frameSize + 4,
+      minHeight: 44,
+      topShare: 0.2,
+      child: button,
+    );
   }
 }

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -93,6 +93,13 @@ class FlowMessageActions extends StatelessWidget {
   /// value, not a scale step.
   static const double _gap = 4;
 
+  /// The strip's reach above its frames on touch platforms: each button
+  /// lays out `touchReach` taller with its frame at the bottom, and
+  /// `FlowMessage` gives up the same 12 of its footer gap, so the frames
+  /// stay put while the strip reaches up into the gap. Sideways each
+  /// takes the strip's pitch.
+  static const double touchReach = 12;
+
   /// Rendered in order.
   final List<FlowMessageAction> actions;
 
@@ -204,12 +211,12 @@ class _ActionButtonState extends State<_ActionButton> {
       button = Tooltip(message: tooltip, child: button);
     }
     // The row keeps the design's 20px frames on a 4px pitch; a finger
-    // gets the pitch sideways and the design's 44 vertically, mostly
-    // downward into the gap between turns, off the text above.
+    // gets the pitch sideways and the footer gap above, the frame seated
+    // at the bottom so it draws where it did.
     return FlowTouchTarget(
-      minWidth: _frameSize + 4,
-      minHeight: 44,
-      topShare: 0.2,
+      minWidth: _frameSize + FlowMessageActions._gap,
+      minHeight: _frameSize + FlowMessageActions.touchReach,
+      topShare: 1,
       child: button,
     );
   }

--- a/lib/src/widgets/flow_message_actions.dart
+++ b/lib/src/widgets/flow_message_actions.dart
@@ -94,10 +94,12 @@ class FlowMessageActions extends StatelessWidget {
   static const double _gap = 4;
 
   /// The strip's reach above its frames on touch platforms: each button
-  /// lays out `touchReach` taller with its frame at the bottom, and
-  /// `FlowMessage` gives up the same 12 of its footer gap, so the frames
-  /// stay put while the strip reaches up into the gap. Sideways each
-  /// takes the strip's pitch.
+  /// lays out this much taller with its frame at the bottom, and
+  /// `FlowMessage` gives up the same run of its footer gap, so the frames
+  /// stay put while the strip reaches up into the gap — or as much of it
+  /// as the gap holds, through [FlowFooterReach]. Sideways the buttons
+  /// share the strip's pitch between them, the edge ones keeping their
+  /// frames flush with the strip's ends.
   static const double touchReach = 12;
 
   /// Rendered in order.
@@ -117,16 +119,31 @@ class FlowMessageActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final effective =
         context.flowTheme.messageActionsStyle?.merge(style) ?? style;
-    // The design's action strip: 15px glyphs on 20px frames, 4 apart.
+    // The design's action strip: 15px glyphs on 20px frames, 4 apart. On
+    // touch the gaps belong to the buttons instead — each edge button
+    // takes half a gap on its outer side, the rest a full gap — so the
+    // pitch and every frame's place are unchanged while a finger between
+    // two frames still lands on one.
+    final touch = FlowTouchTarget.isTouch(context);
+    final last = actions.length - 1;
+    double reachWidth(int i) {
+      if (!touch || last == 0) return _ActionButtonState._frameSize;
+      return _ActionButtonState._frameSize +
+          (i == 0 || i == last ? _gap / 2 : _gap);
+    }
+
+    double leftShare(int i) => i == 0 ? 0 : (i == last ? 1 : 0.5);
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         for (var i = 0; i < actions.length; i++) ...[
-          if (i > 0) const SizedBox(width: _gap),
+          if (i > 0 && !touch) const SizedBox(width: _gap),
           _ActionButton(
             action: actions[i],
             iconSize: iconSize,
             style: effective,
+            reachWidth: reachWidth(i),
+            leftShare: leftShare(i),
           ),
         ],
       ],
@@ -141,11 +158,18 @@ class _ActionButton extends StatefulWidget {
     required this.action,
     required this.iconSize,
     this.style,
+    required this.reachWidth,
+    required this.leftShare,
   });
 
   final FlowMessageAction action;
   final double iconSize;
   final FlowMessageActionsStyle? style;
+
+  /// The button's share of the strip's pitch on touch platforms, and
+  /// where its frame sits in it.
+  final double reachWidth;
+  final double leftShare;
 
   @override
   State<_ActionButton> createState() => _ActionButtonState();
@@ -210,14 +234,33 @@ class _ActionButtonState extends State<_ActionButton> {
     if (tooltip != null) {
       button = Tooltip(message: tooltip, child: button);
     }
-    // The row keeps the design's 20px frames on a 4px pitch; a finger
-    // gets the pitch sideways and the footer gap above, the frame seated
-    // at the bottom so it draws where it did.
+    // The frame keeps its place: its share of the pitch sideways, the
+    // footer gap the message gave up above, seated at the bottom.
+    final reach =
+        FlowFooterReach.maybeOf(context) ?? FlowMessageActions.touchReach;
     return FlowTouchTarget(
-      minWidth: _frameSize + FlowMessageActions._gap,
-      minHeight: _frameSize + FlowMessageActions.touchReach,
+      minWidth: widget.reachWidth,
+      minHeight: _frameSize + reach,
       topShare: 1,
+      leftShare: widget.leftShare,
       child: button,
     );
   }
+}
+
+/// How far a [FlowMessageActions] strip may reach above its frames on
+/// touch platforms: the run of footer gap its message has given up.
+/// `FlowMessage` sets it to the gap it has; a strip on its own takes the
+/// full [FlowMessageActions.touchReach].
+class FlowFooterReach extends InheritedWidget {
+  const FlowFooterReach({super.key, required this.reach, required super.child});
+
+  final double reach;
+
+  static double? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<FlowFooterReach>()?.reach;
+
+  @override
+  bool updateShouldNotify(FlowFooterReach oldWidget) =>
+      reach != oldWidget.reach;
 }

--- a/lib/src/widgets/flow_text_selection.dart
+++ b/lib/src/widgets/flow_text_selection.dart
@@ -48,8 +48,12 @@ class FlowTextSelectionPage extends StatelessWidget {
   final String? closeTooltip;
 
   /// The design's page: the reading inset, the close disc's 32 frame on
-  /// the top bar's 12 inset, the body line, 16 between parts.
-  static const EdgeInsets _bodyPadding = EdgeInsets.fromLTRB(20, 8, 20, 40);
+  /// the top bar's 12 inset, the body line, 16 between parts. The bottom
+  /// inset measures from the safe area's edge and absorbs the home
+  /// indicator rather than stacking on it, the chat view's rule.
+  static const double _sideInset = 20;
+  static const double _bodyTop = 8;
+  static const double _bodyBottom = 40;
   static const EdgeInsets _barPadding = EdgeInsets.fromLTRB(12, 8, 12, 0);
   static const double _closeIconSize = 20;
   static const double _closePadding = 6;
@@ -62,6 +66,14 @@ class FlowTextSelectionPage extends StatelessWidget {
     final typography = context.flowTypography;
     final body = typography.bodyLarge.copyWith(color: colors.onSurface);
     final markdown = message.role == FlowMessageRole.assistant;
+    // Read above the SafeArea, which consumes it: inside, it reads zero.
+    final safeBottom = MediaQuery.paddingOf(context).bottom;
+    final bodyPadding = EdgeInsets.fromLTRB(
+      _sideInset,
+      _bodyTop,
+      _sideInset,
+      (_bodyBottom - safeBottom).clamp(0.0, _bodyBottom),
+    );
 
     final parts = <Widget?>[
       for (final part in message.parts)
@@ -117,7 +129,7 @@ class FlowTextSelectionPage extends StatelessWidget {
               Expanded(
                 child: SelectionArea(
                   child: SingleChildScrollView(
-                    padding: _bodyPadding,
+                    padding: bodyPadding,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [

--- a/lib/src/widgets/flow_text_selection.dart
+++ b/lib/src/widgets/flow_text_selection.dart
@@ -1,56 +1,83 @@
 import 'package:material_ui/material_ui.dart';
 
+import '../models/flow_message_data.dart';
+import '../models/flow_message_part.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';
+import 'flow_code_block.dart';
 import 'flow_markdown.dart';
 
 /// The phones' path to selecting prose — the AI apps' "Select text": a
-/// full-screen page of [text], typeset as markdown on the raised ground,
-/// where a long-press
-/// selects a word and the platform's handles and toolbar do the rest.
-/// Offered from the message menu, since on touch the long-press on the
-/// message is the menu itself; on pointer platforms a thread with
-/// `selectable` on drag-selects in place and never needs this.
+/// full-screen page of [message] on the raised ground, typeset as it was
+/// in the thread, where a long-press selects a word and the platform's
+/// handles and toolbar do the rest. Offered from the message menu, since
+/// on touch the long-press on the message is the menu itself; on pointer
+/// platforms a thread with `selectable` on drag-selects in place and
+/// never needs this.
 ///
-/// [text] is usually [FlowMessageData.plainText]. [closeTooltip] names
-/// the close disc; a `MaterialApp` host gets its own "Close" when null.
+/// [closeTooltip] names the close disc; a `MaterialApp` host gets its own
+/// "Close" when null.
 Future<void> showFlowTextSelection({
   required BuildContext context,
-  required String text,
+  required FlowMessageData message,
   String? closeTooltip,
 }) {
   return Navigator.of(context).push<void>(
     MaterialPageRoute<void>(
       fullscreenDialog: true,
       builder: (context) =>
-          FlowTextSelectionPage(text: text, closeTooltip: closeTooltip),
+          FlowTextSelectionPage(message: message, closeTooltip: closeTooltip),
     ),
   );
 }
 
 /// The page [showFlowTextSelection] pushes; usable directly by a host with
-/// its own routing.
+/// its own routing. Text parts read as they did in the thread — an
+/// assistant's as markdown, a user's as typed — and code parts as code
+/// blocks; attachments and pictures are left out, there being nothing in
+/// them to select.
 class FlowTextSelectionPage extends StatelessWidget {
   const FlowTextSelectionPage({
     super.key,
-    required this.text,
+    required this.message,
     this.closeTooltip,
   });
 
-  final String text;
+  final FlowMessageData message;
   final String? closeTooltip;
 
-  /// The design's page: the reading inset, the close disc's 24 frame on
-  /// the top bar's 12 inset, the body line.
+  /// The design's page: the reading inset, the close disc's 32 frame on
+  /// the top bar's 12 inset, the body line, 16 between parts.
   static const EdgeInsets _bodyPadding = EdgeInsets.fromLTRB(20, 8, 20, 40);
   static const EdgeInsets _barPadding = EdgeInsets.fromLTRB(12, 8, 12, 0);
   static const double _closeIconSize = 20;
   static const double _closePadding = 6;
+  static const double _closeTouch = 44;
+  static const double _partGap = 16;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.flowColors;
     final typography = context.flowTypography;
+    final body = typography.bodyLarge.copyWith(color: colors.onSurface);
+    final markdown = message.role == FlowMessageRole.assistant;
+
+    final parts = <Widget?>[
+      for (final part in message.parts)
+        switch (part) {
+          FlowTextPart() =>
+            markdown
+                ? FlowMarkdown(text: part.text, style: body)
+                : Text(part.text, style: body),
+          FlowCodePart() => FlowCodeBlock(
+            code: part.code,
+            language: part.language,
+            filename: part.filename,
+          ),
+          _ => null,
+        },
+    ].nonNulls.toList();
+
     return Material(
       color: colors.surfaceBright,
       child: SafeArea(
@@ -68,6 +95,7 @@ class FlowTextSelectionPage extends StatelessWidget {
                     foreground: colors.onSurfaceVariant,
                     iconSize: _closeIconSize,
                     padding: _closePadding,
+                    touchMinSize: _closeTouch,
                     tooltip:
                         closeTooltip ??
                         // Not MaterialLocalizations.of: a missing tooltip
@@ -86,13 +114,14 @@ class FlowTextSelectionPage extends StatelessWidget {
               child: SelectionArea(
                 child: SingleChildScrollView(
                   padding: _bodyPadding,
-                  // Typeset, not raw: a reply's markdown reads here as it
-                  // did in the thread, and every run of it selects.
-                  child: FlowMarkdown(
-                    text: text,
-                    style: typography.bodyLarge.copyWith(
-                      color: colors.onSurface,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      for (var i = 0; i < parts.length; i++) ...[
+                        if (i > 0) const SizedBox(height: _partGap),
+                        parts[i],
+                      ],
+                    ],
                   ),
                 ),
               ),

--- a/lib/src/widgets/flow_text_selection.dart
+++ b/lib/src/widgets/flow_text_selection.dart
@@ -1,0 +1,105 @@
+import 'package:material_ui/material_ui.dart';
+
+import '../theme/flow_theme.dart';
+import '../utils/flow_circle_button.dart';
+import 'flow_markdown.dart';
+
+/// The phones' path to selecting prose — the AI apps' "Select text": a
+/// full-screen page of [text], typeset as markdown on the raised ground,
+/// where a long-press
+/// selects a word and the platform's handles and toolbar do the rest.
+/// Offered from the message menu, since on touch the long-press on the
+/// message is the menu itself; on pointer platforms a thread with
+/// `selectable` on drag-selects in place and never needs this.
+///
+/// [text] is usually [FlowMessageData.plainText]. [closeTooltip] names
+/// the close disc; a `MaterialApp` host gets its own "Close" when null.
+Future<void> showFlowTextSelection({
+  required BuildContext context,
+  required String text,
+  String? closeTooltip,
+}) {
+  return Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (context) =>
+          FlowTextSelectionPage(text: text, closeTooltip: closeTooltip),
+    ),
+  );
+}
+
+/// The page [showFlowTextSelection] pushes; usable directly by a host with
+/// its own routing.
+class FlowTextSelectionPage extends StatelessWidget {
+  const FlowTextSelectionPage({
+    super.key,
+    required this.text,
+    this.closeTooltip,
+  });
+
+  final String text;
+  final String? closeTooltip;
+
+  /// The design's page: the reading inset, the close disc's 24 frame on
+  /// the top bar's 12 inset, the body line.
+  static const EdgeInsets _bodyPadding = EdgeInsets.fromLTRB(20, 8, 20, 40);
+  static const EdgeInsets _barPadding = EdgeInsets.fromLTRB(12, 8, 12, 0);
+  static const double _closeIconSize = 20;
+  static const double _closePadding = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.flowColors;
+    final typography = context.flowTypography;
+    return Material(
+      color: colors.surfaceBright,
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: _barPadding,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  FlowCircleButton(
+                    icon: Icons.close,
+                    background: colors.surfaceContainerLow,
+                    foreground: colors.onSurfaceVariant,
+                    iconSize: _closeIconSize,
+                    padding: _closePadding,
+                    tooltip:
+                        closeTooltip ??
+                        // Not MaterialLocalizations.of: a missing tooltip
+                        // must not be the one thing that throws under a
+                        // plain WidgetsApp.
+                        Localizations.of<MaterialLocalizations>(
+                          context,
+                          MaterialLocalizations,
+                        )?.closeButtonTooltip,
+                    onTap: () => Navigator.of(context).maybePop(),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SelectionArea(
+                child: SingleChildScrollView(
+                  padding: _bodyPadding,
+                  // Typeset, not raw: a reply's markdown reads here as it
+                  // did in the thread, and every run of it selects.
+                  child: FlowMarkdown(
+                    text: text,
+                    style: typography.bodyLarge.copyWith(
+                      color: colors.onSurface,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/flow_text_selection.dart
+++ b/lib/src/widgets/flow_text_selection.dart
@@ -4,6 +4,7 @@ import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';
 import '../theme/flow_theme.dart';
 import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
 import 'flow_code_block.dart';
 import 'flow_markdown.dart';
 
@@ -78,55 +79,59 @@ class FlowTextSelectionPage extends StatelessWidget {
         },
     ].nonNulls.toList();
 
-    return Material(
-      color: colors.surfaceBright,
-      child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: _barPadding,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  FlowCircleButton(
-                    icon: Icons.close,
-                    background: colors.surfaceContainerLow,
-                    foreground: colors.onSurfaceVariant,
-                    iconSize: _closeIconSize,
-                    padding: _closePadding,
-                    touchMinSize: _closeTouch,
-                    tooltip:
-                        closeTooltip ??
-                        // Not MaterialLocalizations.of: a missing tooltip
-                        // must not be the one thing that throws under a
-                        // plain WidgetsApp.
-                        Localizations.of<MaterialLocalizations>(
-                          context,
-                          MaterialLocalizations,
-                        )?.closeButtonTooltip,
-                    onTap: () => Navigator.of(context).maybePop(),
-                  ),
-                ],
+    // Its own route, so outside the chat view's selection theme: the
+    // handles and wash take the Flow accent here too.
+    return FlowSelectionTheme(
+      child: Material(
+        color: colors.surfaceBright,
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: _barPadding,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    FlowCircleButton(
+                      icon: Icons.close,
+                      background: colors.surfaceContainerLow,
+                      foreground: colors.onSurfaceVariant,
+                      iconSize: _closeIconSize,
+                      padding: _closePadding,
+                      touchMinSize: _closeTouch,
+                      tooltip:
+                          closeTooltip ??
+                          // Not MaterialLocalizations.of: a missing tooltip
+                          // must not be the one thing that throws under a
+                          // plain WidgetsApp.
+                          Localizations.of<MaterialLocalizations>(
+                            context,
+                            MaterialLocalizations,
+                          )?.closeButtonTooltip,
+                      onTap: () => Navigator.of(context).maybePop(),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            Expanded(
-              child: SelectionArea(
-                child: SingleChildScrollView(
-                  padding: _bodyPadding,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      for (var i = 0; i < parts.length; i++) ...[
-                        if (i > 0) const SizedBox(height: _partGap),
-                        parts[i],
+              Expanded(
+                child: SelectionArea(
+                  child: SingleChildScrollView(
+                    padding: _bodyPadding,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        for (var i = 0; i < parts.length; i++) ...[
+                          if (i > 0) const SizedBox(height: _partGap),
+                          parts[i],
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -6,6 +6,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';
+import '../utils/flow_selection_theme.dart';
 import 'flow_menu.dart' show FlowMenuEntry;
 import 'flow_message.dart';
 
@@ -409,6 +410,8 @@ class _FlowThreadState extends State<FlowThread> {
       ),
     );
     if (!widget.selectable || !pointer) return list;
-    return SelectionArea(child: list);
+    // In the Flow accent wherever the thread is mounted, not only under
+    // the chat view's own selection theme.
+    return FlowSelectionTheme(child: SelectionArea(child: list));
   }
 }

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -6,6 +6,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';
+import 'flow_menu.dart' show FlowMenuEntry;
 import 'flow_message.dart';
 
 /// The scrollable conversation, a list of [FlowMessageData]s.
@@ -37,6 +38,9 @@ class FlowThread extends StatefulWidget {
     this.itemSpacing,
     this.messageBuilder,
     this.messageFooter,
+    this.messageMenu,
+    this.onMessageMenuSelected,
+    this.selectable = true,
     this.charactersPerSecond = 300,
     this.thinkingLabel,
   });
@@ -116,6 +120,24 @@ class FlowThread extends StatefulWidget {
   /// for no footer on that turn. Ignored when [messageBuilder] is set:
   /// the builder owns the whole message.
   final Widget? Function(FlowMessageData message)? messageFooter;
+
+  /// Each message's context menu, the AI apps' long-press: the entries
+  /// for [message], or empty for none — a streaming turn, say. Labels are
+  /// the host's; see [FlowMessage.menuEntries] for how it opens.
+  final List<FlowMenuEntry> Function(FlowMessageData message)? messageMenu;
+
+  /// The chosen option for the message it was opened on.
+  final void Function(FlowMessageData message, String id)?
+  onMessageMenuSelected;
+
+  /// Whether prose can be drag-selected across the conversation on
+  /// pointer platforms — the web's reading convention, copied with the
+  /// platform shortcut. The messages' own gestures sit below the
+  /// selection and keep winning: a right-click still opens
+  /// [messageMenu]. Touch platforms select through the menu instead,
+  /// via `showFlowTextSelection`, since there the long-press *is* the
+  /// menu.
+  final bool selectable;
 
   /// Forwarded to [FlowMessage] for streaming text parts.
   final double charactersPerSecond;
@@ -310,10 +332,15 @@ class _FlowThreadState extends State<FlowThread> {
     final onAttachmentTap = widget.onAttachmentTap;
     final onRetry = widget.onRetry;
     final onLinkTap = widget.onLinkTap;
+    final onMenuSelected = widget.onMessageMenuSelected;
     final messages = widget.messages;
     _syncStreaming(messages);
 
-    return NotificationListener<ScrollEndNotification>(
+    final platform = Theme.of(context).platform;
+    final pointer =
+        platform != TargetPlatform.iOS && platform != TargetPlatform.android;
+
+    Widget list = NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
         if (notification.depth == 0) {
           _settleIfOff(notification.metrics, notification.context);
@@ -370,6 +397,10 @@ class _FlowThreadState extends State<FlowThread> {
                       charactersPerSecond: widget.charactersPerSecond,
                       thinkingLabel: widget.thinkingLabel,
                       footer: widget.messageFooter?.call(message),
+                      menuEntries: widget.messageMenu?.call(message),
+                      onMenuSelected: onMenuSelected == null
+                          ? null
+                          : (id) => onMenuSelected(message, id),
                     ),
               );
             },
@@ -377,5 +408,7 @@ class _FlowThreadState extends State<FlowThread> {
         ),
       ),
     );
+    if (!widget.selectable || !pointer) return list;
+    return SelectionArea(child: list);
   }
 }

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:material_ui/material_ui.dart';
 
@@ -158,6 +159,15 @@ class _FlowThreadState extends State<FlowThread> {
   bool _fits = false;
   Timer? _fitsHold;
 
+  /// The list's controller when the host passes none: the settle below
+  /// needs a position to correct, and the notification alone offers none.
+  ScrollController? _internalController;
+  ScrollController get _controller =>
+      widget.controller ?? (_internalController ??= ScrollController());
+
+  /// Whether a settle is already queued for the frame's end.
+  bool _settling = false;
+
   /// Whether any message is mid-turn, read each build. The fit flip is
   /// frozen while streaming: swapping the list's viewport type remounts
   /// the whole subtree, resetting every reveal — mid-stream that reset
@@ -174,10 +184,63 @@ class _FlowThreadState extends State<FlowThread> {
   @override
   void dispose() {
     _fitsHold?.cancel();
+    _internalController?.dispose();
     super.dispose();
   }
 
+  /// How far outside its range an idle position may sit before it is
+  /// pulled back: sub-pixel drift is not a stranded offset.
+  static const double _settleTolerance = 0.5;
+
+  static bool _inRange(ScrollMetrics metrics) =>
+      metrics.pixels >= metrics.minScrollExtent - _settleTolerance &&
+      metrics.pixels <= metrics.maxScrollExtent + _settleTolerance;
+
+  /// An idle position must sit inside its range. Flutter leaves one that
+  /// has already left it where it is: `RangeMaintainingScrollPhysics`
+  /// stops enforcing the boundary once a position is out of range and
+  /// carries the overshoot as the range shrinks, and only a gesture's
+  /// ballistic pulls it back. The keyboard is how it gets there — a drag
+  /// dismisses it (the default `keyboardDismissBehavior`), the viewport
+  /// grows mid-gesture while a reply is still growing, and the range
+  /// collapses under the offset. A reversed list stranded past its end
+  /// shows its content shifted down, the newest message clipped under the
+  /// list's own bottom edge and the jump button hidden below its
+  /// threshold: a thread cut off mid-screen with blank space beneath. Past
+  /// its start, a blank band above the oldest message instead. Clamping
+  /// back in is what the physics does at the end of every gesture, done
+  /// here for the idle case it skips.
+  ///
+  /// Runs on every metrics change and on every scroll end: the range
+  /// collapses mid-gesture, when a jump would fight the physics, and a
+  /// gesture merely ending changes no metrics — so each covers the other.
+  /// The correction goes through the controller, which needs a single
+  /// position; a host sharing one across lists opts out of the settle.
+  void _settleIfOff(ScrollMetrics metrics) {
+    if (_settling || _inRange(metrics)) return;
+    _settling = true;
+    // Metrics arrive during layout; the jump waits for the frame's end.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _settling = false;
+      if (!mounted) return;
+      final controller = _controller;
+      if (!controller.hasClients || controller.positions.length != 1) return;
+      final position = controller.position;
+      // Re-read live: the offset the notification reported may have moved
+      // on, and a gesture or its ballistic in progress settles on its own.
+      if (position.isScrollingNotifier.value || _inRange(position)) return;
+      controller.jumpTo(
+        clampDouble(
+          position.pixels,
+          position.minScrollExtent,
+          position.maxScrollExtent,
+        ),
+      );
+    });
+  }
+
   void _handleMetrics(ScrollMetrics metrics) {
+    _settleIfOff(metrics);
     final fits = metrics.maxScrollExtent <= 0;
     final first = _metricsFits == null;
     _metricsFits = fits;
@@ -255,57 +318,63 @@ class _FlowThreadState extends State<FlowThread> {
     final messages = widget.messages;
     _syncStreaming(messages);
 
-    return NotificationListener<ScrollMetricsNotification>(
+    return NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
-        // Depth 0 is the thread's own list — scrollers nested inside
-        // messages (attachment strips, code blocks) report deeper and
-        // must not steer the fit.
-        if (notification.depth == 0) _handleMetrics(notification.metrics);
+        if (notification.depth == 0) _settleIfOff(notification.metrics);
         return false;
       },
-      child: Align(
-        alignment: AlignmentDirectional.topCenter,
-        child: ListView.builder(
-          controller: widget.controller,
-          reverse: true,
-          shrinkWrap: _fits,
-          scrollCacheExtent: _cacheExtent,
-          keyboardDismissBehavior: widget.keyboardDismissBehavior,
-          padding: widget.padding ?? _defaultPadding,
-          itemCount: messages.length,
-          itemBuilder: (context, index) {
-            // Reversed list: index 0 is the newest (bottom) message.
-            final message = messages[messages.length - 1 - index];
-            final isOldest = index == messages.length - 1;
-            return Padding(
-              key: ValueKey(message.id),
-              padding: EdgeInsets.only(top: isOldest ? 0 : gap),
-              child:
-                  widget.messageBuilder?.call(context, message) ??
-                  FlowMessage(
-                    message,
-                    customPartBuilder: widget.customPartBuilder,
-                    onAttachmentTap: onAttachmentTap == null
-                        ? null
-                        : (attachmentId) =>
-                              onAttachmentTap(message, attachmentId),
-                    previewCloseTooltip: widget.previewCloseTooltip,
-                    onCodeCopy: widget.onCodeCopy,
-                    copiedCodePart: widget.copiedCodePart,
-                    codeCopyTooltip: widget.codeCopyTooltip,
-                    markdown: widget.markdown,
-                    onLinkTap: onLinkTap == null
-                        ? null
-                        : (href) => onLinkTap(message, href),
-                    onRetry: onRetry == null ? null : () => onRetry(message),
-                    errorTitle: widget.errorTitle,
-                    retryLabel: widget.retryLabel,
-                    charactersPerSecond: widget.charactersPerSecond,
-                    thinkingLabel: widget.thinkingLabel,
-                    footer: widget.messageFooter?.call(message),
-                  ),
-            );
-          },
+      child: NotificationListener<ScrollMetricsNotification>(
+        onNotification: (notification) {
+          // Depth 0 is the thread's own list — scrollers nested inside
+          // messages (attachment strips, code blocks) report deeper and
+          // must not steer the fit.
+          if (notification.depth == 0) _handleMetrics(notification.metrics);
+          return false;
+        },
+        child: Align(
+          alignment: AlignmentDirectional.topCenter,
+          child: ListView.builder(
+            controller: _controller,
+            reverse: true,
+            shrinkWrap: _fits,
+            scrollCacheExtent: _cacheExtent,
+            keyboardDismissBehavior: widget.keyboardDismissBehavior,
+            padding: widget.padding ?? _defaultPadding,
+            itemCount: messages.length,
+            itemBuilder: (context, index) {
+              // Reversed list: index 0 is the newest (bottom) message.
+              final message = messages[messages.length - 1 - index];
+              final isOldest = index == messages.length - 1;
+              return Padding(
+                key: ValueKey(message.id),
+                padding: EdgeInsets.only(top: isOldest ? 0 : gap),
+                child:
+                    widget.messageBuilder?.call(context, message) ??
+                    FlowMessage(
+                      message,
+                      customPartBuilder: widget.customPartBuilder,
+                      onAttachmentTap: onAttachmentTap == null
+                          ? null
+                          : (attachmentId) =>
+                                onAttachmentTap(message, attachmentId),
+                      previewCloseTooltip: widget.previewCloseTooltip,
+                      onCodeCopy: widget.onCodeCopy,
+                      copiedCodePart: widget.copiedCodePart,
+                      codeCopyTooltip: widget.codeCopyTooltip,
+                      markdown: widget.markdown,
+                      onLinkTap: onLinkTap == null
+                          ? null
+                          : (href) => onLinkTap(message, href),
+                      onRetry: onRetry == null ? null : () => onRetry(message),
+                      errorTitle: widget.errorTitle,
+                      retryLabel: widget.retryLabel,
+                      charactersPerSecond: widget.charactersPerSecond,
+                      thinkingLabel: widget.thinkingLabel,
+                      footer: widget.messageFooter?.call(message),
+                    ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -159,12 +159,6 @@ class _FlowThreadState extends State<FlowThread> {
   bool _fits = false;
   Timer? _fitsHold;
 
-  /// The list's controller when the host passes none: the settle below
-  /// needs a position to correct, and the notification alone offers none.
-  ScrollController? _internalController;
-  ScrollController get _controller =>
-      widget.controller ?? (_internalController ??= ScrollController());
-
   /// Whether a settle is already queued for the frame's end.
   bool _settling = false;
 
@@ -184,7 +178,6 @@ class _FlowThreadState extends State<FlowThread> {
   @override
   void dispose() {
     _fitsHold?.cancel();
-    _internalController?.dispose();
     super.dispose();
   }
 
@@ -214,22 +207,24 @@ class _FlowThreadState extends State<FlowThread> {
   /// Runs on every metrics change and on every scroll end: the range
   /// collapses mid-gesture, when a jump would fight the physics, and a
   /// gesture merely ending changes no metrics — so each covers the other.
-  /// The correction goes through the controller, which needs a single
-  /// position; a host sharing one across lists opts out of the settle.
-  void _settleIfOff(ScrollMetrics metrics) {
-    if (_settling || _inRange(metrics)) return;
+  /// The correction goes through the position that fired the
+  /// notification, found from its context, so the list needs no
+  /// controller of its own and keeps the primary one a host relies on for
+  /// the chat view's scrollbar and the status-bar tap.
+  void _settleIfOff(ScrollMetrics metrics, BuildContext? context) {
+    if (context == null || _settling || _inRange(metrics)) return;
+    final scrollable = context.findAncestorStateOfType<ScrollableState>();
+    if (scrollable == null) return;
     _settling = true;
     // Metrics arrive during layout; the jump waits for the frame's end.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _settling = false;
-      if (!mounted) return;
-      final controller = _controller;
-      if (!controller.hasClients || controller.positions.length != 1) return;
-      final position = controller.position;
+      if (!mounted || !scrollable.mounted) return;
+      final position = scrollable.position;
       // Re-read live: the offset the notification reported may have moved
       // on, and a gesture or its ballistic in progress settles on its own.
       if (position.isScrollingNotifier.value || _inRange(position)) return;
-      controller.jumpTo(
+      position.jumpTo(
         clampDouble(
           position.pixels,
           position.minScrollExtent,
@@ -239,8 +234,8 @@ class _FlowThreadState extends State<FlowThread> {
     });
   }
 
-  void _handleMetrics(ScrollMetrics metrics) {
-    _settleIfOff(metrics);
+  void _handleMetrics(ScrollMetrics metrics, BuildContext context) {
+    _settleIfOff(metrics, context);
     final fits = metrics.maxScrollExtent <= 0;
     final first = _metricsFits == null;
     _metricsFits = fits;
@@ -320,7 +315,9 @@ class _FlowThreadState extends State<FlowThread> {
 
     return NotificationListener<ScrollEndNotification>(
       onNotification: (notification) {
-        if (notification.depth == 0) _settleIfOff(notification.metrics);
+        if (notification.depth == 0) {
+          _settleIfOff(notification.metrics, notification.context);
+        }
         return false;
       },
       child: NotificationListener<ScrollMetricsNotification>(
@@ -328,13 +325,15 @@ class _FlowThreadState extends State<FlowThread> {
           // Depth 0 is the thread's own list — scrollers nested inside
           // messages (attachment strips, code blocks) report deeper and
           // must not steer the fit.
-          if (notification.depth == 0) _handleMetrics(notification.metrics);
+          if (notification.depth == 0) {
+            _handleMetrics(notification.metrics, notification.context);
+          }
           return false;
         },
         child: Align(
           alignment: AlignmentDirectional.topCenter,
           child: ListView.builder(
-            controller: _controller,
+            controller: widget.controller,
             reverse: true,
             shrinkWrap: _fits,
             scrollCacheExtent: _cacheExtent,

--- a/playground/lib/src/demo_registry.dart
+++ b/playground/lib/src/demo_registry.dart
@@ -113,6 +113,7 @@ List<(String, String)> variantsFor(PlaygroundItem item) {
       ('default', 'Default'),
       ('streaming', 'Streaming'),
       ('short', 'Short'),
+      ('menu', 'Long-press menu'),
     ],
     PlaygroundItem.threadList => const [
       ('sections', 'Sections'),

--- a/playground/lib/src/demos/thread_demo.dart
+++ b/playground/lib/src/demos/thread_demo.dart
@@ -53,10 +53,11 @@ FlowThread(
   ],
   onMessageMenuSelected: (message, id) => switch (id) {
     // Phones select prose from the menu: a full-screen page of the
-    // message's plain text. Pointer platforms drag-select in place.
+    // message, typeset as in the thread. Pointer platforms drag-select
+    // in place.
     'select' => showFlowTextSelection(
       context: context,
-      text: message.plainText,
+      message: message,
       closeTooltip: 'Close',
     ),
     _ => handle(message, id),
@@ -212,7 +213,7 @@ class _ThreadDemoState extends State<ThreadDemo> {
     if (id == 'select') {
       showFlowTextSelection(
         context: context,
-        text: message.plainText,
+        message: message,
         closeTooltip: 'Close',
       );
       return;

--- a/playground/lib/src/demos/thread_demo.dart
+++ b/playground/lib/src/demos/thread_demo.dart
@@ -7,6 +7,7 @@ import 'package:material_ui/material_ui.dart';
 String threadSnippet([String? variant]) => switch (variant) {
   'streaming' => _streaming,
   'short' => _short,
+  'menu' => _menu,
   _ => _default,
 };
 
@@ -33,6 +34,33 @@ const String _short = '''
 SizedBox(
   height: 480,
   child: FlowThread(messages: fewMessages),
+)''';
+
+const String _menu = '''
+// The context menu: long-press with a haptic on touch, right-click on
+// pointer platforms — a sheet on phones, a popover at the pointer
+// elsewhere. Entries and labels are the host's; the id comes back with
+// the message it was opened on.
+FlowThread(
+  messages: messages,
+  messageMenu: (message) => [
+    FlowMenuOption(id: 'copy', icon: Icons.copy_outlined, label: 'Copy'),
+    FlowMenuOption(id: 'select', icon: Icons.text_fields, label: 'Select text'),
+    if (message.role == FlowMessageRole.assistant)
+      FlowMenuOption(id: 'again', icon: Icons.refresh, label: 'Regenerate'),
+    FlowMenuDivider(),
+    FlowMenuOption(id: 'delete', icon: Icons.delete_outline, label: 'Delete'),
+  ],
+  onMessageMenuSelected: (message, id) => switch (id) {
+    // Phones select prose from the menu: a full-screen page of the
+    // message's plain text. Pointer platforms drag-select in place.
+    'select' => showFlowTextSelection(
+      context: context,
+      text: message.plainText,
+      closeTooltip: 'Close',
+    ),
+    _ => handle(message, id),
+  },
 )''';
 
 const String _default = '''
@@ -151,9 +179,46 @@ class _ThreadDemoState extends State<ThreadDemo> {
             codeCopyTooltip: 'Copy code',
             copiedCodePart: _copiedPart,
             onCodeCopy: _copy,
+            messageMenu: widget.variant == 'menu' ? _menuFor : null,
+            onMessageMenuSelected: widget.variant == 'menu' ? _onMenu : null,
           ),
         ),
       ),
     );
+  }
+
+  List<FlowMenuEntry> _menuFor(FlowMessageData message) => [
+    const FlowMenuOption(id: 'copy', icon: Icons.copy_outlined, label: 'Copy'),
+    const FlowMenuOption(
+      id: 'select',
+      icon: Icons.text_fields,
+      label: 'Select text',
+    ),
+    if (message.role == FlowMessageRole.assistant)
+      const FlowMenuOption(
+        id: 'again',
+        icon: Icons.refresh,
+        label: 'Regenerate',
+      ),
+    const FlowMenuDivider(),
+    const FlowMenuOption(
+      id: 'delete',
+      icon: Icons.delete_outline,
+      label: 'Delete',
+    ),
+  ];
+
+  void _onMenu(FlowMessageData message, String id) {
+    if (id == 'select') {
+      showFlowTextSelection(
+        context: context,
+        text: message.plainText,
+        closeTooltip: 'Close',
+      );
+      return;
+    }
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('$id · ${message.id}')));
   }
 }


### PR DESCRIPTION
## Summary

One PR for what was the stack #35, #36, #37: retargeted to `main` with the commits unchanged, so the two PRs beneath are folded in here and closed.

**Message menu and selectable prose** (the tip, #37)

- `FlowThread.messageMenu(message)` hands back a message's entries (`FlowMenuOption`s and dividers, labels the host's) and `onMessageMenuSelected(message, id)` reports the pick; `FlowMessage` takes the pair as `menuEntries` and `onMenuSelected`. A long-press with a haptic on touch, a right-click on pointer platforms; the phone sheet or a popover at the pointer, by the theme's platform like the other menus. Hit-testing defers to the child, so the blank run beside a user bubble is not the message, and controls with their own long-press (tooltips, code blocks) keep it.
- `FlowMenu`'s entry-to-rows and sheet builders move to `flow_menu_entries.dart` and are shared with the message menu, so one `entries` list reads the same wherever it opens.
- `FlowThread.selectable` (on by default) makes the conversation a `SelectionArea` on pointer platforms; it sits above the messages, so their gestures still win and right-click still opens the menu. Phones select from the menu instead: `showFlowTextSelection` pushes a full-screen page of a message's text, typeset through `FlowMarkdown` inside a `SelectionArea`, and `FlowMessageData.plainText` is the text to hand it.
- Example: copy, select text, feedback, regenerate and delete in the menu. Playground: a Long-press menu variant on the thread stage. Docs sections for both.

**Phone pass: touch targets, control names, the caret** (was #36)

- New `FlowTouchTarget` widens hit areas to a finger's 44 to 48px on touch platforms without changing layout, sized per site so a neighbour's taps stay its own; applied to the message actions, the attach, send, stop, remove and error-dismiss discs, the menu triggers and the code block's copy. Pointer platforms pass straight through.
- `FlowComposer.sendTooltip` and `stopTooltip` name the discs, so VoiceOver no longer announces an unnamed button.
- New `FlowSelectionTheme` derives the caret, selection wash, handles and Cupertino primary from `FlowColors`, so a host on a stock `ThemeData` no longer gets Material's purple; wraps the chat view and the composer.
- The example gates its web-only drop and paste callbacks with `kIsWeb`, silencing the two runtime warnings it logged on iOS.

**Thread settle** (was #35)

- Fixes the thread stranding at a scroll offset outside its range: the newest message clipped under the list's bottom edge, or a blank band above the oldest. The keyboard is the way in: a drag dismisses it, the viewport grows mid-gesture while a reply is still growing, and the range collapses under the offset, which `RangeMaintainingScrollPhysics` then carries.
- `FlowThread` now clamps an idle position back into range, on every metrics change and on every scroll end, each covering the other's blind spot. The list gets its own controller when the host passes none; a host sharing one controller across lists opts out of the settle.

## Screenshots

The menu sheet, the select text page and the caret before and after are attached on the original PRs (#36, #37 comments). The settle fix removes a broken state rather than changing a drawn one.

## How this was verified

- iPhone 17 Pro simulator, example app, light and dark: hold on a user bubble opens the sheet with Copy and Delete; hold on assistant prose, then Select text, opens the typeset page; a hold on the actions row still shows its tooltip. Caret colour after hot reload; layout unchanged around the message actions, composer row and code block header; XXXL Dynamic Type still lays out. Send with the keyboard up, drag the thread to dismiss it while the reply streams; the reply stays pinned above the composer and the settled thread reads from the top.
- Desktop `SelectionArea` path is analyzer-verified only; it is not exercisable on iOS.
- `flutter analyze` clean at the root and in `example/` and `playground/`; `dart format .` applied.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)
