### PR TITLE
feat: app bar and thread drawer in the example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,10 @@
   select from the menu: `showFlowTextSelection` pushes a full-screen page
   of a message, typeset as it was in the thread, for the platform's
   handles; `FlowMessageData.plainText` joins its text for a copy.
+- **Fix** — the chat view's jump-to-latest button follows a thread that
+  remounts, as a host keying `FlowThread` per conversation does: the new
+  list's first metrics reset it rather than the last list's offset
+  lingering until a scroll.
 
 ## 0.2.0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,6 +80,11 @@ class _ChatScreenState extends State<ChatScreen> {
   String _activeThread = 't0';
   int _nextThread = 1;
 
+  /// The composer's text, and each thread's draft while another is on
+  /// screen — a draft belongs to the conversation it was typed in.
+  final TextEditingController _draft = TextEditingController();
+  final Map<String, String> _drafts = {};
+
   List<FlowMessageData> get _messages => _threads[_activeThread] ?? const [];
   set _messages(List<FlowMessageData> value) => _threads[_activeThread] = value;
 
@@ -97,6 +102,8 @@ class _ChatScreenState extends State<ChatScreen> {
   void _openThread(String id) {
     if (id == _activeThread) return;
     if (_generating) _stop();
+    _drafts[_activeThread] = _draft.text;
+    _draft.text = _drafts[id] ?? '';
     setState(() {
       _activeThread = id;
       _pending.clear();
@@ -108,6 +115,8 @@ class _ChatScreenState extends State<ChatScreen> {
     // An untouched thread is already the new chat.
     if (_messages.isEmpty) return;
     if (_generating) _stop();
+    _drafts[_activeThread] = _draft.text;
+    _draft.clear();
     setState(() {
       _activeThread = 't${_nextThread++}';
       _threads[_activeThread] = const [];
@@ -155,6 +164,7 @@ class _ChatScreenState extends State<ChatScreen> {
     _copiedReset?.cancel();
     _reply?.cancel();
     _scroll.dispose();
+    _draft.dispose();
     super.dispose();
   }
 
@@ -720,6 +730,7 @@ class _ChatScreenState extends State<ChatScreen> {
         threadController: _scroll,
         jumpToLatestTooltip: 'Jump to latest',
         composer: FlowComposer(
+          controller: _draft,
           isStreaming: _generating,
           onSend: _send,
           onStop: _stop,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,7 +72,51 @@ class _ChatScreenState extends State<ChatScreen> {
 
   final ScrollController _scroll = ScrollController();
 
-  List<FlowMessageData> _messages = const [];
+  /// Every conversation this screen has held, newest first, and the one
+  /// on screen. The thread list in the drawer reads these; the chat view
+  /// only ever sees the active one.
+  final Map<String, List<FlowMessageData>> _threads = {'t0': const []};
+  final List<String> _threadOrder = ['t0'];
+  String _activeThread = 't0';
+  int _nextThread = 1;
+
+  List<FlowMessageData> get _messages => _threads[_activeThread] ?? const [];
+  set _messages(List<FlowMessageData> value) => _threads[_activeThread] = value;
+
+  /// A thread is named by its opening question.
+  String _titleOf(String id) {
+    for (final message in _threads[id] ?? const <FlowMessageData>[]) {
+      if (message.role != FlowMessageRole.user) continue;
+      final text = message.plainText.trim();
+      if (text.isEmpty) continue;
+      return text.length > 40 ? '${text.substring(0, 40)}…' : text;
+    }
+    return 'New chat';
+  }
+
+  void _openThread(String id) {
+    if (id == _activeThread) return;
+    _stop();
+    setState(() {
+      _activeThread = id;
+      _pending.clear();
+      _rejection = null;
+    });
+  }
+
+  void _newThread() {
+    // An untouched thread is already the new chat.
+    if (_messages.isEmpty) return;
+    _stop();
+    setState(() {
+      _activeThread = 't${_nextThread++}';
+      _threads[_activeThread] = const [];
+      _threadOrder.insert(0, _activeThread);
+      _pending.clear();
+      _rejection = null;
+    });
+  }
+
   StreamSubscription<GeminiDelta>? _reply;
   int _nextId = 0;
   String _model = 'gemini-3.6-flash';
@@ -541,12 +585,101 @@ class _ChatScreenState extends State<ChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.flowColors;
+    final typography = context.flowTypography;
     return Scaffold(
-      backgroundColor: context.flowColors.surface,
+      backgroundColor: colors.surface,
+      // The app's own chrome, in the Flow tokens: a flat bar on the page
+      // ground, the thread's title, the drawer and a new chat.
+      appBar: AppBar(
+        backgroundColor: colors.surface,
+        surfaceTintColor: Colors.transparent,
+        foregroundColor: colors.onSurface,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        centerTitle: true,
+        title: Text(
+          _titleOf(_activeThread),
+          style: typography.labelLargeEmphasised.copyWith(
+            color: colors.onSurface,
+          ),
+          overflow: TextOverflow.ellipsis,
+        ),
+        leading: Builder(
+          builder: (context) => IconButton(
+            icon: const Icon(Icons.menu),
+            tooltip: 'Chats',
+            onPressed: () => Scaffold.of(context).openDrawer(),
+          ),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.edit_square),
+            tooltip: 'New chat',
+            onPressed: _newThread,
+          ),
+        ],
+      ),
+      drawer: Drawer(
+        backgroundColor: colors.surfaceBright,
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 8, 4),
+                child: Row(
+                  children: [
+                    Text(
+                      'Chats',
+                      style: typography.titleSmallEmphasised.copyWith(
+                        color: colors.onSurface,
+                      ),
+                    ),
+                    const Spacer(),
+                    Builder(
+                      builder: (context) => IconButton(
+                        icon: const Icon(Icons.edit_square),
+                        tooltip: 'New chat',
+                        color: colors.onSurfaceVariant,
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          _newThread();
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Builder(
+                  builder: (context) => FlowThreadList(
+                    sections: [
+                      FlowThreadListSection(
+                        label: 'Today',
+                        items: [
+                          for (final id in _threadOrder)
+                            FlowThreadListItem(
+                              id: id,
+                              title: _titleOf(id),
+                              tooltip: _titleOf(id),
+                            ),
+                        ],
+                      ),
+                    ],
+                    selectedId: _activeThread,
+                    onThreadSelected: (id) {
+                      Navigator.of(context).pop();
+                      _openThread(id);
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
       body: FlowChatView(
-        // Drag-and-drop, handled by the package. Web only — the SDK
-        // implements OS file drop nowhere else — and a no-op elsewhere,
-        // which is why the attach button carries the same job.
         // Web only: the SDK implements OS file drop nowhere else, and the
         // package says so at runtime when handed the callback elsewhere.
         onAttachmentsDropped: kIsWeb ? _addAttachments : null,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -92,7 +92,7 @@ class _ChatScreenState extends State<ChatScreen> {
   String _titleOf(String id) {
     for (final message in _threads[id] ?? const <FlowMessageData>[]) {
       if (message.role != FlowMessageRole.user) continue;
-      final text = message.plainText.trim();
+      final text = message.plainText.replaceAll(RegExp(r'\s+'), ' ').trim();
       if (text.isEmpty) continue;
       return text.length > 40 ? '${text.substring(0, 40)}…' : text;
     }
@@ -256,6 +256,9 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _generate() {
     final id = 'a${_nextId++}';
+    // The turn stays with this conversation even if another is opened
+    // before its last delta or its picture's measurement lands.
+    final thread = _activeThread;
     final history = List.of(_messages);
     final generatesImages = _imageModels.contains(_model);
     setState(() {
@@ -328,12 +331,17 @@ class _ChatScreenState extends State<ChatScreen> {
                       if (ratio == null || !identical(picture, bytes)) return;
                       aspectRatio = ratio;
                       if (_messages.any((m) => m.id == id)) {
-                        _update(id, parts: parts(settled: _reply == null));
+                        _update(
+                          id,
+                          thread: thread,
+                          parts: parts(settled: _reply == null),
+                        );
                       }
                     });
                 }
                 _update(
                   id,
+                  thread: thread,
                   parts: parts(settled: false),
                   status: FlowMessageStatus.streaming,
                 );
@@ -343,6 +351,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 failed = true;
                 _update(
                   id,
+                  thread: thread,
                   status: FlowMessageStatus.error,
                   parts: [
                     ...parts(settled: true),
@@ -373,6 +382,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 } else {
                   _update(
                     id,
+                    thread: thread,
                     parts: parts(settled: true),
                     status: FlowMessageStatus.complete,
                   );
@@ -582,15 +592,19 @@ class _ChatScreenState extends State<ChatScreen> {
     _generate();
   }
 
+  /// Rewrites one turn, in [thread] — the conversation it belongs to,
+  /// which a decode landing late may no longer be the one on screen.
   void _update(
     String id, {
     List<FlowMessagePart>? parts,
     FlowMessageStatus? status,
+    String? thread,
   }) {
     if (!mounted) return;
+    final target = thread ?? _activeThread;
     setState(() {
-      _messages = [
-        for (final m in _messages)
+      _threads[target] = [
+        for (final m in _threads[target] ?? const <FlowMessageData>[])
           if (m.id == id) m.copyWith(parts: parts, status: status) else m,
       ];
     });
@@ -616,6 +630,7 @@ class _ChatScreenState extends State<ChatScreen> {
           style: typography.labelLargeEmphasised.copyWith(
             color: colors.onSurface,
           ),
+          maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
         leading: Builder(
@@ -705,6 +720,8 @@ class _ChatScreenState extends State<ChatScreen> {
           text: 'Good afternoon',
         ),
         thread: FlowThread(
+          // A fresh list per conversation: its own offset and fit state.
+          key: ValueKey(_activeThread),
           messages: _messages,
           controller: _scroll,
           thinkingLabel: 'Thinking…',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -96,7 +96,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _openThread(String id) {
     if (id == _activeThread) return;
-    _stop();
+    if (_generating) _stop();
     setState(() {
       _activeThread = id;
       _pending.clear();
@@ -107,7 +107,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void _newThread() {
     // An untouched thread is already the new chat.
     if (_messages.isEmpty) return;
-    _stop();
+    if (_generating) _stop();
     setState(() {
       _activeThread = 't${_nextThread++}';
       _threads[_activeThread] = const [];
@@ -389,6 +389,9 @@ class _ChatScreenState extends State<ChatScreen> {
   /// arrived yet, where completing would leave an empty turn: the still
   /// pending reply is removed instead.
   void _stop() {
+    // Only a turn in flight has anything to stop: the composer calls this
+    // while streaming, and a thread switch may not be.
+    if (!_generating) return;
     _reply?.cancel();
     _reply = null;
     final last = _messages.last;

--- a/lib/src/widgets/flow_chat_view.dart
+++ b/lib/src/widgets/flow_chat_view.dart
@@ -570,7 +570,17 @@ class _FlowChatViewState extends State<FlowChatView> {
       controller: widget.threadController,
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-        child: thread,
+        // The controller only speaks when its offset moves; a thread that
+        // remounts — a host keying it per conversation — attaches a fresh
+        // position at zero in silence, and the jump button would keep
+        // the last conversation's state. Its first metrics say otherwise.
+        child: NotificationListener<ScrollMetricsNotification>(
+          onNotification: (notification) {
+            if (notification.depth == 0) _handleScroll();
+            return false;
+          },
+          child: thread,
+        ),
       ),
     );
     if (widget.threadController == null) return scrollArea;


### PR DESCRIPTION
## Summary

The example gets app chrome: a flat `AppBar` in the Flow tokens with the thread's title (its opening question), a drawer button and a new-chat action, and a `Drawer` holding a `FlowThreadList` over the screen's conversations. Stacked on #37.

- The screen now holds a map of threads; `_messages` is the active one, so the chat wiring is unchanged. Switching threads stops any stream and clears the pending attachments.
- One package change alongside: `FlowChatView` re-reads its jump-to-latest state from the thread's first metrics, so a thread keyed per conversation does not carry the last one's button.

## Screenshots

| App bar | Drawer |
| --- | --- |
| attached separately | attached separately |

## How this was verified

- iPhone 17 Pro simulator: title updates on send, the drawer lists the thread under Today with the selection fill, new chat from the bar and the drawer.
- `flutter analyze` clean in `example/`; `dart format .` applied.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [x] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only UI and local state; no package API or auth/network changes.
> 
> **Overview**
> The **example chat screen** gains multi-conversation hosting and navigation chrome, without changing the `flow_ui` package.
> 
> Message state moves from a single list into a **thread map** with an active id; `_messages` stays a getter/setter on the active thread so send/stream logic is largely unchanged. Users can **open threads** and **start new chats** from a Flow-styled **AppBar** (title from the first user message) and a **drawer** wired to `FlowThreadList`. **Per-thread composer drafts** are saved when switching; switching also stops in-flight generation and clears pending attachments. Streaming and late image measurement call `_update` with the **originating thread id** so replies still land on the right conversation if the user navigates away mid-stream. `FlowThread` gets a `ValueKey` per thread for separate scroll state, and `_stop` no-ops when nothing is generating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180930348d9c02a56e7b3c126c0cc372ad110870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->