### PR TITLE
feat: selectable prose in the thread, and the select-text page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,14 @@
   body and the inline span, drop from 14 to 13 on their 1.6 and 1.5
   lines.
 
+- **Selecting text** — `FlowThread.selectable` (on by default) makes the
+  conversation a `SelectionArea` on pointer platforms: drag across turns,
+  copy with the shortcut, the messages' own gestures still winning
+  beneath. Phones select through `showFlowTextSelection` instead, pushed
+  from a control of the host's: a full-screen page of a message, typeset
+  as it was in the thread, for the platform's handles;
+  `FlowMessageData.plainText` joins its text for a copy.
+
 ## 0.2.0
 
 - **Typography** — title and label roles now carry an emphasised cut

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Values come from the Flow UI Figma file. Role names follow Material 3's `ColorSc
 
 | # | Component | Variants / notes | Status |
 |---|-----------|------------------|--------|
-| 8 | Message & Thread | ink-wash user bubble; plain assistant | ✅ |
+| 8 | Message & Thread | ink-wash user bubble; plain assistant; selectable prose | ✅ |
 | 9 | Thread List | host-labeled sections; unread dot, pinned glyph, leading icon slot; single selection by id | ✅ |
 | 10 | Message actions | | ✅ |
 | 11 | Streaming text | | ✅ |

--- a/docs/src/content/docs/components/message-thread.mdx
+++ b/docs/src/content/docs/components/message-thread.mdx
@@ -93,6 +93,27 @@ FlowMessage(
 )
 ```
 
+## Selecting text
+
+On pointer platforms the thread is a `SelectionArea` by default
+(`selectable`): drag across turns, copy with the platform shortcut. The
+messages' own gestures sit below it and keep winning. Phones select from
+a control of yours instead — there a drag scrolls and the long-press is
+spoken for — through `showFlowTextSelection`: it pushes a full-screen
+page of the message, typeset as it was in the thread, where a long-press
+selects a word and the platform's handles take over.
+
+```dart title="Select text from your own control"
+showFlowTextSelection(
+  context: context,
+  message: message,
+  closeTooltip: 'Close',
+);
+```
+
+`FlowMessageData.plainText` is the same content as text — the text and
+code parts in order — for a copy action beside it.
+
 ## Message parts
 
 Message content is typed parts, not strings: a sealed `FlowMessagePart`

--- a/lib/flow_ui.dart
+++ b/lib/flow_ui.dart
@@ -50,6 +50,7 @@ export 'src/widgets/flow_streaming_text.dart';
 export 'src/widgets/flow_suggestion.dart';
 export 'src/styles/flow_suggestion_style.dart';
 export 'src/widgets/flow_thinking_indicator.dart';
+export 'src/widgets/flow_text_selection.dart';
 export 'src/widgets/flow_thread.dart';
 export 'src/widgets/flow_thread_list.dart';
 export 'src/styles/flow_thread_list_style.dart';

--- a/lib/src/models/flow_message_data.dart
+++ b/lib/src/models/flow_message_data.dart
@@ -79,4 +79,16 @@ class FlowMessageData {
       timestamp: timestamp ?? this.timestamp,
     );
   }
+
+  /// The message as text: text parts and code in order, a blank line
+  /// between them, attachments and images left out — what a copy or a
+  /// select-text page carries.
+  String get plainText => [
+    for (final part in parts)
+      switch (part) {
+        FlowTextPart() => part.text,
+        FlowCodePart() => part.code,
+        _ => null,
+      },
+  ].nonNulls.join('\n\n');
 }

--- a/lib/src/utils/flow_selection_theme.dart
+++ b/lib/src/utils/flow_selection_theme.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart' show CupertinoTheme;
+import 'package:material_ui/material_ui.dart';
+
+import '../theme/flow_theme.dart';
+
+/// Text editing and selection in the Flow accent: the caret, the selection
+/// wash and the handles, plus the Cupertino primary that iOS draws its
+/// handles and toolbar with. Without this a host that installs [FlowTheme]
+/// on a stock `ThemeData` gets Material's default purple caret against
+/// Flow's primary — the one place the accent otherwise leaks through from
+/// the host's `ColorScheme`.
+class FlowSelectionTheme extends StatelessWidget {
+  const FlowSelectionTheme({super.key, required this.child});
+
+  final Widget child;
+
+  /// The selection wash: the accent at Material's own 40%.
+  static const double _selectionAlpha = 0.4;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = context.flowColors.primary;
+    return TextSelectionTheme(
+      data: TextSelectionThemeData(
+        cursorColor: primary,
+        selectionColor: primary.withValues(alpha: _selectionAlpha),
+        selectionHandleColor: primary,
+      ),
+      child: CupertinoTheme(
+        data: CupertinoTheme.of(context).copyWith(primaryColor: primary),
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/flow_text_selection.dart
+++ b/lib/src/widgets/flow_text_selection.dart
@@ -1,0 +1,149 @@
+import 'package:material_ui/material_ui.dart';
+
+import '../models/flow_message_data.dart';
+import '../models/flow_message_part.dart';
+import '../theme/flow_theme.dart';
+import '../utils/flow_circle_button.dart';
+import '../utils/flow_selection_theme.dart';
+import 'flow_code_block.dart';
+import 'flow_markdown.dart';
+
+/// The phones' path to selecting prose — the AI apps' "Select text": a
+/// full-screen page of [message] on the raised ground, typeset as it was
+/// in the thread, where a long-press selects a word and the platform's
+/// handles and toolbar do the rest. Offered from the message menu, since
+/// on touch the long-press on the message is the menu itself; on pointer
+/// platforms a thread with `selectable` on drag-selects in place and
+/// never needs this.
+///
+/// [closeTooltip] names the close disc; a `MaterialApp` host gets its own
+/// "Close" when null.
+Future<void> showFlowTextSelection({
+  required BuildContext context,
+  required FlowMessageData message,
+  String? closeTooltip,
+}) {
+  return Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (context) =>
+          FlowTextSelectionPage(message: message, closeTooltip: closeTooltip),
+    ),
+  );
+}
+
+/// The page [showFlowTextSelection] pushes; usable directly by a host with
+/// its own routing. Text parts read as they did in the thread — an
+/// assistant's as markdown, a user's as typed — and code parts as code
+/// blocks; attachments and pictures are left out, there being nothing in
+/// them to select.
+class FlowTextSelectionPage extends StatelessWidget {
+  const FlowTextSelectionPage({
+    super.key,
+    required this.message,
+    this.closeTooltip,
+  });
+
+  final FlowMessageData message;
+  final String? closeTooltip;
+
+  /// The design's page: the reading inset, the close disc's 32 frame on
+  /// the top bar's 12 inset, the body line, 16 between parts. The bottom
+  /// inset measures from the safe area's edge and absorbs the home
+  /// indicator rather than stacking on it, the chat view's rule.
+  static const double _sideInset = 20;
+  static const double _bodyTop = 8;
+  static const double _bodyBottom = 40;
+  static const EdgeInsets _barPadding = EdgeInsets.fromLTRB(12, 8, 12, 0);
+  static const double _closeIconSize = 20;
+  static const double _closePadding = 6;
+  static const double _partGap = 16;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.flowColors;
+    final typography = context.flowTypography;
+    final body = typography.bodyLarge.copyWith(color: colors.onSurface);
+    final markdown = message.role == FlowMessageRole.assistant;
+    // Read above the SafeArea, which consumes it: inside, it reads zero.
+    final safeBottom = MediaQuery.paddingOf(context).bottom;
+    final bodyPadding = EdgeInsets.fromLTRB(
+      _sideInset,
+      _bodyTop,
+      _sideInset,
+      (_bodyBottom - safeBottom).clamp(0.0, _bodyBottom),
+    );
+
+    final parts = <Widget?>[
+      for (final part in message.parts)
+        switch (part) {
+          FlowTextPart() =>
+            markdown
+                ? FlowMarkdown(text: part.text, style: body)
+                : Text(part.text, style: body),
+          FlowCodePart() => FlowCodeBlock(
+            code: part.code,
+            language: part.language,
+            filename: part.filename,
+          ),
+          _ => null,
+        },
+    ].nonNulls.toList();
+
+    // Its own route, so outside the chat view's selection theme: the
+    // handles and wash take the Flow accent here too.
+    return FlowSelectionTheme(
+      child: Material(
+        color: colors.surfaceBright,
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: _barPadding,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    FlowCircleButton(
+                      icon: Icons.close,
+                      background: colors.surfaceContainerLow,
+                      foreground: colors.onSurfaceVariant,
+                      iconSize: _closeIconSize,
+                      padding: _closePadding,
+                      tooltip:
+                          closeTooltip ??
+                          // Not MaterialLocalizations.of: a missing tooltip
+                          // must not be the one thing that throws under a
+                          // plain WidgetsApp.
+                          Localizations.of<MaterialLocalizations>(
+                            context,
+                            MaterialLocalizations,
+                          )?.closeButtonTooltip,
+                      onTap: () => Navigator.of(context).maybePop(),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: SelectionArea(
+                  child: SingleChildScrollView(
+                    padding: bodyPadding,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        for (var i = 0; i < parts.length; i++) ...[
+                          if (i > 0) const SizedBox(height: _partGap),
+                          parts[i],
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/flow_thread.dart
+++ b/lib/src/widgets/flow_thread.dart
@@ -5,6 +5,7 @@ import 'package:material_ui/material_ui.dart';
 
 import '../models/flow_message_data.dart';
 import '../models/flow_message_part.dart';
+import '../utils/flow_selection_theme.dart';
 import 'flow_message.dart';
 
 /// The scrollable conversation, a list of [FlowMessageData]s.
@@ -36,6 +37,7 @@ class FlowThread extends StatefulWidget {
     this.itemSpacing,
     this.messageBuilder,
     this.messageFooter,
+    this.selectable = true,
     this.charactersPerSecond = 300,
     this.thinkingLabel,
   });
@@ -115,6 +117,15 @@ class FlowThread extends StatefulWidget {
   /// for no footer on that turn. Ignored when [messageBuilder] is set:
   /// the builder owns the whole message.
   final Widget? Function(FlowMessageData message)? messageFooter;
+
+  /// Whether prose can be drag-selected across the conversation on
+  /// pointer platforms — the web's reading convention, copied with the
+  /// platform shortcut. The messages' own gestures sit below the
+  /// selection and keep winning. Touch platforms select through
+  /// `showFlowTextSelection` instead, pushed from a control of the
+  /// host's, since there a drag scrolls and the long-press is spoken
+  /// for.
+  final bool selectable;
 
   /// Forwarded to [FlowMessage] for streaming text parts.
   final double charactersPerSecond;
@@ -255,7 +266,11 @@ class _FlowThreadState extends State<FlowThread> {
     final messages = widget.messages;
     _syncStreaming(messages);
 
-    return NotificationListener<ScrollMetricsNotification>(
+    final platform = Theme.of(context).platform;
+    final pointer =
+        platform != TargetPlatform.iOS && platform != TargetPlatform.android;
+
+    Widget list = NotificationListener<ScrollMetricsNotification>(
       onNotification: (notification) {
         // Depth 0 is the thread's own list — scrollers nested inside
         // messages (attachment strips, code blocks) report deeper and
@@ -309,5 +324,9 @@ class _FlowThreadState extends State<FlowThread> {
         ),
       ),
     );
+    if (!widget.selectable || !pointer) return list;
+    // In the Flow accent wherever the thread is mounted, not only under
+    // the chat view's own selection theme.
+    return FlowSelectionTheme(child: SelectionArea(child: list));
   }
 }


### PR DESCRIPTION
## Summary

The selectable prose half of #37, split out so it can land on its own; #37 keeps the message menu, the phone pass and the settle fix.

- **Drag-select on pointer platforms.** `FlowThread.selectable` (on by default) wraps the conversation in a `SelectionArea`: drag across turns, copy with the platform shortcut. The messages' own gestures sit below it and keep winning. Touch platforms are never wrapped, since there a drag scrolls and the long-press is spoken for.
- **The select-text page.** `showFlowTextSelection` pushes a full-screen page of a message on the raised ground, typeset as it was in the thread (text as markdown, code as code blocks; attachments and pictures left out, there being nothing in them to select), where a long-press selects a word and the platform's handles take over. `FlowTextSelectionPage` is public for a host with its own routing. It is the phones' selection route, pushed from a control of the host's; the message menu that offers it in the design arrives with #37.
- **`FlowMessageData.plainText`** joins the text and code parts in order, for a copy action beside the page.
- **`FlowSelectionTheme`** (internal) puts the caret, wash, handles and the Cupertino primary in the Flow accent; the thread's selection and the page's route both apply it, so selection reads in the accent wherever the thread is mounted.

Two seams with #37, both deliberate:

- `flow_text_selection.dart`, `flow_selection_theme.dart`, `flow_message_data.dart` and the barrel are byte-identical with #37's branch, so its later merge from `main` is clean there.
- The one divergence: the page's close disc drops `touchMinSize`, which belongs to #37's touch-target work; the finger-sized reach comes back when that lands.

## Screenshots

The selection wash and the select-text page render exactly as on #37, where their screenshots are attached; nothing new is drawn beyond them.

## How this was verified

- Throwaway widget tests (run, then deleted; `test/` stays empty): the thread wraps in `SelectionArea` with the accent selection theme on macOS by default, `selectable: false` and Android opt out, the page typesets markdown and a code block inside a `SelectionArea` and its close disc pops the route, and `plainText` joins text and code with a blank line.
- Not exercised in the playground in this pass; the thread stage drag-selects by default on desktop web.
- `flutter analyze` clean at the root and in `example/` and `playground/`; `dart format .` applied; the docs site builds.

## Checklist

- [x] `flutter analyze lib` and `flutter analyze` in `example/` and `playground/` are clean
- [x] `dart format .` applied
- [ ] Exercised in the playground — with a stage demo added or updated if this is a new component or variant
- [x] Any new entry under `dependencies:` in `pubspec.yaml` is flutter.dev-published, forces no configuration on hosts that never use the feature, and is argued in this PR
- [x] Nothing model-facing — no prompts, schemas, or provider/network calls
- [x] New public API is exported from `lib/flow_ui.dart` and documented in `docs/` and the README table
- [x] `CHANGELOG.md` updated for user-facing changes, with breaking changes called out
- [x] PR title follows conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and selection behavior with a default-on thread flag; no auth, data, or model-facing changes.
> 
> **Overview**
> Adds **conversation text selection** on desktop/web and a **full-screen select-text route** for phones, plus a **`plainText` helper** for copy actions.
> 
> **`FlowThread`** gains `selectable` (default **true**). On pointer platforms (not iOS/Android), the list is wrapped in **`SelectionArea`** inside **`FlowSelectionTheme`** so drag-select works across turns and copy uses the platform shortcut; message gestures stay underneath. Touch platforms skip the wrapper—hosts open **`showFlowTextSelection`** from their own control instead.
> 
> **`showFlowTextSelection`** pushes **`FlowTextSelectionPage`**: message text/code typeset like the thread (markdown for assistant, plain text for user, code blocks; attachments/images omitted) in a scrollable **`SelectionArea`**, with a close disc. **`FlowMessageData.plainText`** concatenates text and code parts (blank line between) for copy beside the page.
> 
> **`FlowSelectionTheme`** (internal) aligns caret, selection wash, handles, and Cupertino primary with Flow’s accent. Public API is exported from **`flow_ui.dart`**; docs and changelog updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289fbfcc78f6b42d6c3eb4f9c83db314135b10dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->